### PR TITLE
Upgrade to newest DD Package Version

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,82 @@
+# Generated from CLion C/C++ Code Style settings
+BasedOnStyle:                              LLVM
+AccessModifierOffset:                      -4
+AlignAfterOpenBracket:                     Align
+AlignConsecutiveAssignments:               Consecutive
+AlignConsecutiveDeclarations:              Consecutive
+AlignEscapedNewlines:                      Left
+AlignOperands:                             AlignAfterOperator
+AlignTrailingComments:                     true
+AllowAllArgumentsOnNextLine:               true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine:             Empty
+AllowShortCaseLabelsOnASingleLine:         true
+AllowShortEnumsOnASingleLine:              true
+AllowShortFunctionsOnASingleLine:          Inline
+AllowShortIfStatementsOnASingleLine:       WithoutElse
+AllowShortLambdasOnASingleLine:            All
+AllowShortLoopsOnASingleLine:              true
+AlwaysBreakAfterReturnType:                None
+AlwaysBreakTemplateDeclarations:           Yes
+BreakBeforeBraces:                         Custom
+BraceWrapping:
+  AfterCaseLabel:        false
+  AfterClass:            false
+  AfterControlStatement: Never
+  AfterEnum:             false
+  AfterFunction:         false
+  AfterNamespace:        false
+  AfterUnion:            false
+  BeforeCatch:           false
+  BeforeElse:            false
+  IndentBraces:          false
+  SplitEmptyFunction:    false
+  SplitEmptyRecord:      false
+BreakBeforeBinaryOperators:                None
+BreakBeforeTernaryOperators:               false
+BreakConstructorInitializers:              AfterColon
+BreakInheritanceList:                      AfterColon
+ColumnLimit:                               0
+CompactNamespaces:                         false
+ContinuationIndentWidth:                   8
+Cpp11BracedListStyle:                      true
+DeriveLineEnding:                          true
+EmptyLineBeforeAccessModifier:             LogicalBlock
+IncludeBlocks:                             Regroup
+IndentCaseBlocks:                          false
+IndentCaseLabels:                          true
+IndentPPDirectives:                        BeforeHash
+IndentWidth:                               4
+KeepEmptyLinesAtTheStartOfBlocks:          false
+Language:                                  Cpp
+MaxEmptyLinesToKeep:                       1
+NamespaceIndentation:                      All
+ObjCSpaceAfterProperty:                    false
+ObjCSpaceBeforeProtocolList:               true
+PointerAlignment:                          Left
+ReflowComments:                            false
+SortIncludes:                              true
+SpaceAfterCStyleCast:                      false
+SpaceAfterLogicalNot:                      false
+SpaceAfterTemplateKeyword:                 false
+SpaceBeforeAssignmentOperators:            true
+SpaceBeforeCaseColon:                      false
+SpaceBeforeCpp11BracedList:                false
+SpaceBeforeCtorInitializerColon:           false
+SpaceBeforeInheritanceColon:               false
+SpaceBeforeParens:                         ControlStatements
+SpaceBeforeRangeBasedForLoopColon:         false
+SpaceBeforeSquareBrackets:                 false
+SpaceInEmptyBlock:                         false
+SpaceInEmptyParentheses:                   false
+SpacesBeforeTrailingComments:              1
+SpacesInAngles:                            false
+SpacesInConditionalStatement:              false
+SpacesInCStyleCastParentheses:             false
+SpacesInContainerLiterals:                 false
+SpacesInParentheses:                       false
+SpacesInSquareBrackets:                    false
+Standard:                                  c++17
+TabWidth:                                  4
+UseTab:                                    Never

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
         node-version: [ 10.x, 12.x, 14.x, 15.x ]
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [ 10.x, 12.x, 14.x, 15.x ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm run build --if-present
+
+  codestyle:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - uses: DoozyX/clang-format-lint-action@v0.12
+        with:
+          source:             'cpp/module'
+          extensions:         'h,hpp,c,cpp'
+          clangFormatVersion: 12

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.15...3.19)
 
 # detailed description
 project(DDVis
-        VERSION 1.3.0
+        VERSION 1.4.0
         DESCRIPTION "DDVis - A JKQ Tool for Visualizing Decision Diagrams for Quantum Computing"
         LANGUAGES CXX)
 

--- a/cpp/module/QDDVer.cpp
+++ b/cpp/module/QDDVer.cpp
@@ -790,7 +790,7 @@ Napi::Value QDDVer::GetDD(const Napi::CallbackInfo& info) {
 
     std::stringstream ss{};
     try {
-        dd::toDot(sim, ss, this->showColors, this->showEdgeLabels, this->showClassic);
+        dd::toDot(sim, ss, this->showColors, this->showEdgeLabels, this->showClassic, false, this->usePolarCoordinates);
         std::string str = ss.str();
         state.Set("dot", Napi::String::New(env, str));
         state.Set("amplitudes", Napi::Float32Array::New(env, 0));
@@ -798,7 +798,7 @@ Napi::Value QDDVer::GetDD(const Napi::CallbackInfo& info) {
 
     } catch (std::exception& e) {
         std::cout << "Exception while getting the DD: " << e.what() << std::endl;
-        std::cout << "The values of the Flags are: " << this->showColors << ", " << this->showEdgeLabels << ", " << this->showClassic << std::endl;
+        std::cout << "The values of the Flags are: " << this->showColors << ", " << this->showEdgeLabels << ", " << this->showClassic << ", " << this->usePolarCoordinates << std::endl;
         std::string err = "Invalid getDD()-call! "; // + e.what();
         Napi::Error::New(env, err).ThrowAsJavaScriptException();
         return Napi::String::New(env, "-1");
@@ -813,8 +813,8 @@ Napi::Value QDDVer::GetDD(const Napi::CallbackInfo& info) {
 void QDDVer::UpdateExportOptions(const Napi::CallbackInfo& info) {
     Napi::Env env = info.Env();
     //check if the correct parameters have been passed
-    if (info.Length() != 3) {
-        Napi::RangeError::New(env, "Need 3 (bool, bool, bool) arguments!").ThrowAsJavaScriptException();
+    if (info.Length() != 4) {
+        Napi::RangeError::New(env, "Need 4 (bool, bool, bool, bool) arguments!").ThrowAsJavaScriptException();
         return;
     }
     if (!info[0].IsBoolean()) { //colored
@@ -829,10 +829,15 @@ void QDDVer::UpdateExportOptions(const Napi::CallbackInfo& info) {
         Napi::TypeError::New(env, "arg3: Boolean expected!").ThrowAsJavaScriptException();
         return;
     }
+    if (!info[3].IsBoolean()) { //classic
+        Napi::TypeError::New(env, "arg4: Boolean expected!").ThrowAsJavaScriptException();
+        return;
+    }
 
-    this->showColors     = (bool)info[0].As<Napi::Boolean>();
-    this->showEdgeLabels = (bool)info[1].As<Napi::Boolean>();
-    this->showClassic    = (bool)info[2].As<Napi::Boolean>();
+    this->showColors          = (bool)info[0].As<Napi::Boolean>();
+    this->showEdgeLabels      = (bool)info[1].As<Napi::Boolean>();
+    this->showClassic         = (bool)info[2].As<Napi::Boolean>();
+    this->usePolarCoordinates = (bool)info[3].As<Napi::Boolean>();
 }
 
 Napi::Value QDDVer::GetExportOptions(const Napi::CallbackInfo& info) {
@@ -842,6 +847,7 @@ Napi::Value QDDVer::GetExportOptions(const Napi::CallbackInfo& info) {
     state.Set("colored", this->showColors);
     state.Set("edgeLabels", this->showEdgeLabels);
     state.Set("classic", this->showClassic);
+    state.Set("polar", this->usePolarCoordinates);
     return state;
 }
 

--- a/cpp/module/QDDVer.h
+++ b/cpp/module/QDDVer.h
@@ -6,15 +6,14 @@
 #ifndef QDD_VIS_QDDVER_H
 #define QDD_VIS_QDDVER_H
 
-#include <napi.h>
-#include <string>
-#include <iostream>
-#include <string>
-#include <memory>
-
 #include "QuantumComputation.hpp"
 
-class QDDVer : public Napi::ObjectWrap<QDDVer> {
+#include <iostream>
+#include <memory>
+#include <napi.h>
+#include <string>
+
+class QDDVer: public Napi::ObjectWrap<QDDVer> {
 public:
     static Napi::Object Init(Napi::Env env, Napi::Object exports);
     explicit QDDVer(const Napi::CallbackInfo& info);
@@ -23,47 +22,47 @@ private:
     static inline Napi::FunctionReference constructor;
 
     //"private" methods
-    void stepForward(bool algo1);   //whether it is applied on algo1 or algo2
-    void stepBack(bool algo1);      //whether it is applied on algo1 or algo2
-    void stepToStart(bool algo1);   //whether it is applied on algo1 or algo2
+    void stepForward(bool algo1); //whether it is applied on algo1 or algo2
+    void stepBack(bool algo1);    //whether it is applied on algo1 or algo2
+    void stepToStart(bool algo1); //whether it is applied on algo1 or algo2
 
     //exported ("public") methods       - return type must be Napi::Value or void!
-    Napi::Value GetDD(const Napi::CallbackInfo& info);  //isVector: false
+    Napi::Value GetDD(const Napi::CallbackInfo& info); //isVector: false
     Napi::Value Load(const Napi::CallbackInfo& info);
     Napi::Value ToStart(const Napi::CallbackInfo& info);
     Napi::Value Next(const Napi::CallbackInfo& info);
     Napi::Value Prev(const Napi::CallbackInfo& info);
     Napi::Value ToEnd(const Napi::CallbackInfo& info);
     Napi::Value ToLine(const Napi::CallbackInfo& info);
-    void UpdateExportOptions(const Napi::CallbackInfo& info);
+    void        UpdateExportOptions(const Napi::CallbackInfo& info);
     Napi::Value GetExportOptions(const Napi::CallbackInfo& info);
     Napi::Value IsReady(const Napi::CallbackInfo& info);
-    void Unready(const Napi::CallbackInfo& info);
+    void        Unready(const Napi::CallbackInfo& info);
 
     //fields
     std::unique_ptr<dd::Package> dd;
-    qc::MatrixDD sim{};
+    qc::MatrixDD                 sim{};
 
     //options for the DD export
-    bool showColors = true;
+    bool showColors     = true;
     bool showEdgeLabels = true;
-    bool showClassic = false;
+    bool showClassic    = false;
 
-    std::unique_ptr<qc::QuantumComputation> qc1;
-    std::vector<std::unique_ptr<qc::Operation>>::iterator iterator1{};  //operations of algo1
-    unsigned int position1 = 0;  //current position of iterator1
+    std::unique_ptr<qc::QuantumComputation>               qc1;
+    std::vector<std::unique_ptr<qc::Operation>>::iterator iterator1{};   //operations of algo1
+    unsigned int                                          position1 = 0; //current position of iterator1
 
-    bool ready1 = false;     //true if algo1 is valid
+    bool ready1     = false; //true if algo1 is valid
     bool atInitial1 = true;  //whether we're currently before the first operation of algo1
-    bool atEnd1 = false;     //whether we're currently after the last operation of algo1
+    bool atEnd1     = false; //whether we're currently after the last operation of algo1
 
-    std::unique_ptr<qc::QuantumComputation> qc2;
-    std::vector<std::unique_ptr<qc::Operation>>::iterator iterator2{};  //operations of algo2
-    unsigned int position2 = 0;  //current position of iterator2
+    std::unique_ptr<qc::QuantumComputation>               qc2;
+    std::vector<std::unique_ptr<qc::Operation>>::iterator iterator2{};   //operations of algo2
+    unsigned int                                          position2 = 0; //current position of iterator2
 
-    bool ready2 = false;     //true if algo2 is valid
-    bool atInitial2 = true; //whether we're currently before the first operation of algo2
-    bool atEnd2 = false;    //whether we're currently after the last operation of algo2
+    bool ready2     = false; //true if algo2 is valid
+    bool atInitial2 = true;  //whether we're currently before the first operation of algo2
+    bool atEnd2     = false; //whether we're currently after the last operation of algo2
 };
 
 #endif //QDD_VIS_QDDVER_H

--- a/cpp/module/QDDVer.h
+++ b/cpp/module/QDDVer.h
@@ -44,9 +44,10 @@ private:
     qc::MatrixDD                 sim{};
 
     //options for the DD export
-    bool showColors     = true;
-    bool showEdgeLabels = true;
-    bool showClassic    = false;
+    bool showColors          = true;
+    bool showEdgeLabels      = true;
+    bool showClassic         = false;
+    bool usePolarCoordinates = true;
 
     std::unique_ptr<qc::QuantumComputation>               qc1;
     std::vector<std::unique_ptr<qc::Operation>>::iterator iterator1{};   //operations of algo1

--- a/cpp/module/QDDVis.cpp
+++ b/cpp/module/QDDVis.cpp
@@ -711,7 +711,7 @@ Napi::Value QDDVis::GetDD(const Napi::CallbackInfo& info) {
 
     std::stringstream ss{};
     try {
-        dd::toDot(sim, ss, this->showColors, this->showEdgeLabels, this->showClassic);
+        dd::toDot(sim, ss, this->showColors, this->showEdgeLabels, this->showClassic, false, this->usePolarCoordinates);
         std::string str = ss.str();
         state.Set("dot", Napi::String::New(env, str));
         state.Set("amplitudes", Napi::Float32Array::New(env, 0));
@@ -724,7 +724,7 @@ Napi::Value QDDVis::GetDD(const Napi::CallbackInfo& info) {
 
     } catch (std::exception& e) {
         std::cout << "Exception while getting the DD: " << e.what() << std::endl;
-        std::cout << "The values of the Flags are: " << this->showColors << ", " << this->showEdgeLabels << ", " << this->showClassic << std::endl;
+        std::cout << "The values of the Flags are: " << this->showColors << ", " << this->showEdgeLabels << ", " << this->showClassic << ", " << this->usePolarCoordinates << std::endl;
         std::string err = "Invalid getDD()-call! "; // + e.what();
         Napi::Error::New(env, err).ThrowAsJavaScriptException();
         return Napi::String::New(env, "-1");
@@ -739,8 +739,8 @@ Napi::Value QDDVis::GetDD(const Napi::CallbackInfo& info) {
 void QDDVis::UpdateExportOptions(const Napi::CallbackInfo& info) {
     Napi::Env env = info.Env();
     //check if the correct parameters have been passed
-    if (info.Length() != 3) {
-        Napi::RangeError::New(env, "Need 3 (bool, bool, bool) arguments!").ThrowAsJavaScriptException();
+    if (info.Length() != 4) {
+        Napi::RangeError::New(env, "Need 4 (bool, bool, bool, bool) arguments!").ThrowAsJavaScriptException();
         return;
     }
     if (!info[0].IsBoolean()) { //colored
@@ -755,11 +755,15 @@ void QDDVis::UpdateExportOptions(const Napi::CallbackInfo& info) {
         Napi::TypeError::New(env, "arg3: Boolean expected!").ThrowAsJavaScriptException();
         return;
     }
+    if (!info[3].IsBoolean()) { //classic
+        Napi::TypeError::New(env, "arg4: Boolean expected!").ThrowAsJavaScriptException();
+        return;
+    }
 
-    this->showColors     = (bool)info[0].As<Napi::Boolean>();
-    this->showEdgeLabels = (bool)info[1].As<Napi::Boolean>();
-    this->showClassic    = (bool)info[2].As<Napi::Boolean>();
-    //std::cout << "Updated the values of the Flags to: " << this->showColors << ", " << this->showEdgeLabels << ", " << this->showClassic << std::endl;
+    this->showColors          = (bool)info[0].As<Napi::Boolean>();
+    this->showEdgeLabels      = (bool)info[1].As<Napi::Boolean>();
+    this->showClassic         = (bool)info[2].As<Napi::Boolean>();
+    this->usePolarCoordinates = (bool)info[3].As<Napi::Boolean>();
 }
 
 Napi::Value QDDVis::GetExportOptions(const Napi::CallbackInfo& info) {
@@ -769,6 +773,7 @@ Napi::Value QDDVis::GetExportOptions(const Napi::CallbackInfo& info) {
     state.Set("colored", this->showColors);
     state.Set("edgeLabels", this->showEdgeLabels);
     state.Set("classic", this->showClassic);
+    state.Set("polar", this->usePolarCoordinates);
     return state;
 }
 

--- a/cpp/module/QDDVis.cpp
+++ b/cpp/module/QDDVis.cpp
@@ -4,29 +4,27 @@
  */
 
 #include "QDDVis.h"
+
 #include "dd/Export.hpp"
 
 Napi::Object QDDVis::Init(Napi::Env env, Napi::Object exports) {
     Napi::HandleScope scope(env);
 
     Napi::Function func =
-        DefineClass(  env,
+            DefineClass(env,
                         "QDDVis",
-                        {
-                            InstanceMethod("load", &QDDVis::Load),
-                            InstanceMethod("toStart", &QDDVis::ToStart),
-                            InstanceMethod("prev", &QDDVis::Prev),
-                            InstanceMethod("next", &QDDVis::Next),
-                            InstanceMethod("toEnd", &QDDVis::ToEnd),
-                            InstanceMethod("toLine", &QDDVis::ToLine),
-                            InstanceMethod("getDD", &QDDVis::GetDD),
-                            InstanceMethod("updateExportOptions", &QDDVis::UpdateExportOptions),
-                            InstanceMethod("getExportOptions", &QDDVis::GetExportOptions),
-                            InstanceMethod("isReady", &QDDVis::IsReady),
-                            InstanceMethod("unready", &QDDVis::Unready),
-                            InstanceMethod("conductIrreversibleOperation", &QDDVis::ConductIrreversibleOperation)
-                        }
-                    );
+                        {InstanceMethod("load", &QDDVis::Load),
+                         InstanceMethod("toStart", &QDDVis::ToStart),
+                         InstanceMethod("prev", &QDDVis::Prev),
+                         InstanceMethod("next", &QDDVis::Next),
+                         InstanceMethod("toEnd", &QDDVis::ToEnd),
+                         InstanceMethod("toLine", &QDDVis::ToLine),
+                         InstanceMethod("getDD", &QDDVis::GetDD),
+                         InstanceMethod("updateExportOptions", &QDDVis::UpdateExportOptions),
+                         InstanceMethod("getExportOptions", &QDDVis::GetExportOptions),
+                         InstanceMethod("isReady", &QDDVis::IsReady),
+                         InstanceMethod("unready", &QDDVis::Unready),
+                         InstanceMethod("conductIrreversibleOperation", &QDDVis::ConductIrreversibleOperation)});
 
     constructor = Napi::Persistent(func);
     constructor.SuppressDestruct();
@@ -35,14 +33,14 @@ Napi::Object QDDVis::Init(Napi::Env env, Napi::Object exports) {
     return exports;
 }
 
-
 //constructor
 /**Parameterless default constructor, just initializes variables
  *
  * @param info takes no parameters
  */
-QDDVis::QDDVis(const Napi::CallbackInfo& info) : Napi::ObjectWrap<QDDVis>(info) {
-    Napi::Env env = info.Env();
+QDDVis::QDDVis(const Napi::CallbackInfo& info):
+    Napi::ObjectWrap<QDDVis>(info) {
+    Napi::Env         env = info.Env();
     Napi::HandleScope scope(env);
 
     this->dd = std::make_unique<dd::Package>(1);
@@ -57,28 +55,28 @@ QDDVis::QDDVis(const Napi::CallbackInfo& info) : Napi::ObjectWrap<QDDVis>(info) 
  *
  */
 void QDDVis::stepForward() {
-    if(atEnd) return;   //no further steps possible
-	qc::MatrixDD currDD{};
+    if (atEnd) return; //no further steps possible
+    qc::MatrixDD currDD{};
     if ((*iterator)->isClassicControlledOperation()) {
-    	auto startIndex = static_cast<dd::Qubit>((*iterator)->getParameter().at(0));
-	    auto length = static_cast<dd::QubitCount>((*iterator)->getParameter().at(1));
-	    auto expectedValue = static_cast<std::size_t>((*iterator)->getParameter().at(2));
+        auto startIndex    = static_cast<dd::Qubit>((*iterator)->getParameter().at(0));
+        auto length        = static_cast<dd::QubitCount>((*iterator)->getParameter().at(1));
+        auto expectedValue = static_cast<std::size_t>((*iterator)->getParameter().at(2));
 
-	    std::size_t value = 0;
-	    for (dd::QubitCount i = 0; i < length; ++i) {
-		    value |= (measurements[startIndex+i] << i);
-	    }
+        std::size_t value = 0;
+        for (dd::QubitCount i = 0; i < length; ++i) {
+            value |= (measurements[startIndex + i] << i);
+        }
 
-	    if (value == expectedValue) {
-		    currDD = (*iterator)->getDD(dd);    //retrieve the "new" current operation
-	    } else {
-	    	currDD = dd->makeIdent(qc->getNqubits());
-	    }
+        if (value == expectedValue) {
+            currDD = (*iterator)->getDD(dd); //retrieve the "new" current operation
+        } else {
+            currDD = dd->makeIdent(qc->getNqubits());
+        }
     } else {
-	    currDD = (*iterator)->getDD(dd);    //retrieve the "new" current operation
+        currDD = (*iterator)->getDD(dd); //retrieve the "new" current operation
     }
 
-    auto temp = dd->multiply(currDD, sim);         //process the current operation by multiplying it with the previous simulation-state
+    auto temp = dd->multiply(currDD, sim); //process the current operation by multiplying it with the previous simulation-state
     dd->incRef(temp);
     dd->decRef(sim);
     sim = temp;
@@ -86,7 +84,7 @@ void QDDVis::stepForward() {
 
     iterator++; // advance iterator
     position++;
-    if (iterator == qc->end()) {    //qc1->end() is after the last operation in the iterator
+    if (iterator == qc->end()) { //qc1->end() is after the last operation in the iterator
         atEnd = true;
     }
 }
@@ -97,7 +95,7 @@ void QDDVis::stepForward() {
  *
  */
 void QDDVis::stepBack() {
-    if(atInitial) return;   //no step back possible
+    if (atInitial) return; //no step back possible
 
     if (iterator == qc->begin()) {
         atInitial = true;
@@ -107,27 +105,27 @@ void QDDVis::stepBack() {
     iterator--; //set iterator back to the desired operation
     position--;
 
-	qc::MatrixDD currDD{};
-	if ((*iterator)->isClassicControlledOperation()) {
-		auto startIndex = static_cast<dd::Qubit>((*iterator)->getParameter().at(0));
-		auto length = static_cast<dd::QubitCount>((*iterator)->getParameter().at(1));
-		auto expectedValue = static_cast<std::size_t>((*iterator)->getParameter().at(2));
+    qc::MatrixDD currDD{};
+    if ((*iterator)->isClassicControlledOperation()) {
+        auto startIndex    = static_cast<dd::Qubit>((*iterator)->getParameter().at(0));
+        auto length        = static_cast<dd::QubitCount>((*iterator)->getParameter().at(1));
+        auto expectedValue = static_cast<std::size_t>((*iterator)->getParameter().at(2));
 
-		std::size_t value = 0;
-		for (dd::QubitCount i = 0; i < length; ++i) {
-			value |= (measurements[startIndex+i] << i);
-		}
+        std::size_t value = 0;
+        for (dd::QubitCount i = 0; i < length; ++i) {
+            value |= (measurements[startIndex + i] << i);
+        }
 
-		if (value == expectedValue) {
-			currDD = (*iterator)->getInverseDD(dd); // get the inverse of the current operation
-		} else {
-			currDD = dd->makeIdent(qc->getNqubits());
-		}
-	} else {
-		currDD = (*iterator)->getInverseDD(dd); // get the inverse of the current operation
-	}
+        if (value == expectedValue) {
+            currDD = (*iterator)->getInverseDD(dd); // get the inverse of the current operation
+        } else {
+            currDD = dd->makeIdent(qc->getNqubits());
+        }
+    } else {
+        currDD = (*iterator)->getInverseDD(dd); // get the inverse of the current operation
+    }
 
-    auto temp = dd->multiply(currDD, sim);   //"remove" the current operation by multiplying with its inverse
+    auto temp = dd->multiply(currDD, sim); //"remove" the current operation by multiplying with its inverse
     dd->incRef(temp);
     dd->decRef(sim);
     sim = temp;
@@ -135,90 +133,90 @@ void QDDVis::stepBack() {
 }
 
 std::pair<dd::fp, dd::fp> QDDVis::getProbabilities(dd::Qubit qubitIdx) const {
-	std::map<dd::Package::vNode*, dd::fp> probsMone;
-	std::set<dd::Package::vNode*> visited_nodes2;
-	std::queue<dd::Package::vNode*> q;
+    std::map<dd::Package::vNode*, dd::fp> probsMone;
+    std::set<dd::Package::vNode*>         visited_nodes2;
+    std::queue<dd::Package::vNode*>       q;
 
-	probsMone[sim.p] = dd::ComplexNumbers::mag2(sim.w);
-	visited_nodes2.insert(sim.p);
-	q.push(sim.p);
+    probsMone[sim.p] = dd::ComplexNumbers::mag2(sim.w);
+    visited_nodes2.insert(sim.p);
+    q.push(sim.p);
 
-	while(q.front()->v != qubitIdx) {
-		auto ptr = q.front();
-		q.pop();
-		auto prob = probsMone[ptr];
+    while (q.front()->v != qubitIdx) {
+        auto ptr = q.front();
+        q.pop();
+        auto prob = probsMone[ptr];
 
-		if(!ptr->e[0].w.approximatelyZero()) {
-			const auto tmp1 = prob * dd::ComplexNumbers::mag2(ptr->e[0].w);
+        if (!ptr->e[0].w.approximatelyZero()) {
+            const auto tmp1 = prob * dd::ComplexNumbers::mag2(ptr->e[0].w);
 
-			if(visited_nodes2.find(ptr->e[0].p) != visited_nodes2.end()) {
-				probsMone[ptr->e[0].p] = probsMone[ptr->e[0].p] + tmp1;
-			} else {
-				probsMone[ptr->e[0].p] = tmp1;
-				visited_nodes2.insert(ptr->e[0].p);
-				q.push(ptr->e[0].p);
-			}
-		}
+            if (visited_nodes2.find(ptr->e[0].p) != visited_nodes2.end()) {
+                probsMone[ptr->e[0].p] = probsMone[ptr->e[0].p] + tmp1;
+            } else {
+                probsMone[ptr->e[0].p] = tmp1;
+                visited_nodes2.insert(ptr->e[0].p);
+                q.push(ptr->e[0].p);
+            }
+        }
 
-		if(!ptr->e[1].w.approximatelyZero()) {
-			const auto tmp1 = prob * dd::ComplexNumbers::mag2(ptr->e[1].w);
+        if (!ptr->e[1].w.approximatelyZero()) {
+            const auto tmp1 = prob * dd::ComplexNumbers::mag2(ptr->e[1].w);
 
-			if(visited_nodes2.find(ptr->e[1].p) != visited_nodes2.end()) {
-				probsMone[ptr->e[1].p] = probsMone[ptr->e[1].p] + tmp1;
-			} else {
-				probsMone[ptr->e[1].p] = tmp1;
-				visited_nodes2.insert(ptr->e[1].p);
-				q.push(ptr->e[1].p);
-			}
-		}
-	}
+            if (visited_nodes2.find(ptr->e[1].p) != visited_nodes2.end()) {
+                probsMone[ptr->e[1].p] = probsMone[ptr->e[1].p] + tmp1;
+            } else {
+                probsMone[ptr->e[1].p] = tmp1;
+                visited_nodes2.insert(ptr->e[1].p);
+                q.push(ptr->e[1].p);
+            }
+        }
+    }
 
-	dd::fp pzero{0}, pone{0};
-	while(!q.empty()) {
-		auto ptr = q.front();
-		q.pop();
+    dd::fp pzero{0}, pone{0};
+    while (!q.empty()) {
+        auto ptr = q.front();
+        q.pop();
 
-		if(!ptr->e[0].w.approximatelyZero()) {
-			pzero += probsMone[ptr] * dd::ComplexNumbers::mag2(ptr->e[0].w);
-		}
+        if (!ptr->e[0].w.approximatelyZero()) {
+            pzero += probsMone[ptr] * dd::ComplexNumbers::mag2(ptr->e[0].w);
+        }
 
-		if(!ptr->e[1].w.approximatelyZero()) {
-			pone += probsMone[ptr] * dd::ComplexNumbers::mag2(ptr->e[1].w);
-		}
-	}
+        if (!ptr->e[1].w.approximatelyZero()) {
+            pone += probsMone[ptr] * dd::ComplexNumbers::mag2(ptr->e[1].w);
+        }
+    }
 
-	return {pzero, pone};
+    return {pzero, pone};
 }
 
 void QDDVis::measureQubit(dd::Qubit qubitIdx, bool measureOne, dd::fp pzero, dd::fp pone) {
-	dd::GateMatrix measure_m{{{0,0}, {0,0},{0,0}, {0,0}}};
+    dd::GateMatrix measure_m{{{0, 0}, {0, 0}, {0, 0}, {0, 0}}};
 
-	dd::fp norm_factor{};
+    dd::fp norm_factor{};
 
-	if(!measureOne) {
-		measure_m[0] = {1,0};
-		norm_factor = pzero;
-	} else {
-		measure_m[3] = {1, 0};
-		norm_factor = pone;
-	}
-	dd::Edge m_gate = dd->makeGateDD(measure_m, qc->getNqubits(), qubitIdx);
-	dd::Edge e = dd->multiply(m_gate, sim);
-	dd->decRef(sim);
+    if (!measureOne) {
+        measure_m[0] = {1, 0};
+        norm_factor  = pzero;
+    } else {
+        measure_m[3] = {1, 0};
+        norm_factor  = pone;
+    }
+    dd::Edge m_gate = dd->makeGateDD(measure_m, qc->getNqubits(), qubitIdx);
+    dd::Edge e      = dd->multiply(m_gate, sim);
+    dd->decRef(sim);
 
-	auto c = dd->cn.getCached(std::sqrt(1.0/norm_factor), 0);
-	dd::ComplexNumbers::mul(c, e.w, c);
-	e.w = dd->cn.lookup(c);
-	dd->incRef(e);
-	sim = e;
+    auto c = dd->cn.getCached(std::sqrt(1.0 / norm_factor), 0);
+    dd::ComplexNumbers::mul(c, e.w, c);
+    e.w = dd->cn.lookup(c);
+    dd->incRef(e);
+    sim = e;
 }
 
 void QDDVis::calculateAmplitudes(Napi::Float32Array& amplitudes) {
-	for(std::size_t i = 0; i < 1ull << qc->getNqubits(); ++i) {
-		auto result = dd->getValueByPath(sim, i);
-		amplitudes[2*i] = static_cast<float>(result.r);
-		amplitudes[2*i+1] = static_cast<float>(result.i);
-	}
+    for (std::size_t i = 0; i < 1ull << qc->getNqubits(); ++i) {
+        auto result           = dd->getValueByPath(sim, i);
+        amplitudes[2 * i]     = static_cast<float>(result.r);
+        amplitudes[2 * i + 1] = static_cast<float>(result.i);
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -231,26 +229,26 @@ void QDDVis::calculateAmplitudes(Napi::Float32Array& amplitudes) {
  * be applied or just the iterator advance forward without applying operations/DDs.
  */
 Napi::Value QDDVis::Load(const Napi::CallbackInfo& info) {
-    Napi::Env env = info.Env();
+    Napi::Env    env   = info.Env();
     Napi::Object state = Napi::Object::New(env);
     state.Set("numOfOperations", Napi::Number::New(env, -1));
     state.Set("nextIsIrreversible", Napi::Boolean::New(env, false));
     state.Set("noGoingBack", Napi::Boolean::New(env, false));
 
     //check if the correct parameters have been passed
-    if(info.Length() < 4) {
+    if (info.Length() < 4) {
         Napi::RangeError::New(env, "Need 4 (String, unsigned int, unsigned int, bool) arguments!").ThrowAsJavaScriptException();
         return state;
     }
-    if (!info[0].IsString()) {  //algorithm
+    if (!info[0].IsString()) { //algorithm
         Napi::TypeError::New(env, "arg1: String expected!").ThrowAsJavaScriptException();
         return state;
     }
-    if (!info[1].IsNumber()) {  //format code (1 = QASM, 2 = Real)
+    if (!info[1].IsNumber()) { //format code (1 = QASM, 2 = Real)
         Napi::TypeError::New(env, "arg3: unsigned int expected!").ThrowAsJavaScriptException();
         return state;
     }
-    if (!info[2].IsNumber()) {  //number of operations to immediately process
+    if (!info[2].IsNumber()) { //number of operations to immediately process
         Napi::TypeError::New(env, "arg2: unsigned int expected!").ThrowAsJavaScriptException();
         return state;
     }
@@ -260,21 +258,23 @@ Napi::Value QDDVis::Load(const Napi::CallbackInfo& info) {
     }
 
     //the first parameter (algorithm)
-    auto arg = info[0].As<Napi::String>();
+    auto              arg  = info[0].As<Napi::String>();
     const std::string algo = arg.Utf8Value();
     std::stringstream ss{algo};
 
     try {
         //second parameter describes the format of the algorithm
         const unsigned int formatCode = (unsigned int)info[1].As<Napi::Number>();
-        if(formatCode == 1)         qc->import(ss, qc::OpenQASM);
-        else if(formatCode == 2)    qc->import(ss, qc::Real);
+        if (formatCode == 1)
+            qc->import(ss, qc::OpenQASM);
+        else if (formatCode == 2)
+            qc->import(ss, qc::Real);
         else {
             Napi::Error::New(env, "Invalid format-code!").ThrowAsJavaScriptException();
             return state;
         }
 
-    } catch(std::exception& e) {
+    } catch (std::exception& e) {
         std::cout << "Exception while loading the algorithm: " << e.what() << std::endl;
         std::string err(e.what());
         Napi::Error::New(env, "Invalid algorithm!\n" + err).ThrowAsJavaScriptException();
@@ -282,52 +282,52 @@ Napi::Value QDDVis::Load(const Napi::CallbackInfo& info) {
     }
 
     //re-initialize some variables (though depending on opNum they might change in the next lines)
-    ready = true;
+    ready     = true;
     atInitial = true;
-    atEnd = false;
-    iterator = qc->begin();
-    position = 0;
+    atEnd     = false;
+    iterator  = qc->begin();
+    position  = 0;
     // resize the DD package so that it can hold as many variables
     dd->resize(qc->getNqubits());
     measurements.resize(qc->getNqubits());
 
-	state.Set("numOfOperations", Napi::Number::New(env, static_cast<double>(qc->getNops())));
+    state.Set("numOfOperations", Napi::Number::New(env, static_cast<double>(qc->getNops())));
 
     //the third parameter (how many operations to apply immediately)
-    unsigned int opNum = (unsigned int)info[2].As<Napi::Number>();    //at this point opNum may be bigger than the number of operations the algorithm has!
-    if(opNum > qc->getNops()) opNum = qc->getNops();
-    if(opNum > 0) {
-        atInitial = false;
+    unsigned int opNum = (unsigned int)info[2].As<Napi::Number>(); //at this point opNum may be bigger than the number of operations the algorithm has!
+    if (opNum > qc->getNops()) opNum = qc->getNops();
+    if (opNum > 0) {
+        atInitial          = false;
         const bool process = (bool)info[3].As<Napi::Boolean>(); //the fourth parameter tells us to process iterated operations or not
-        if(process) {
-            if(sim.p != nullptr) {
+        if (process) {
+            if (sim.p != nullptr) {
                 dd->decRef(sim);
             }
             sim = dd->makeZeroState(qc->getNqubits());
             dd->incRef(sim);
 
-            for(unsigned int i = 0; i < opNum; i++) {    //apply some operations
+            for (unsigned int i = 0; i < opNum; i++) { //apply some operations
                 stepForward();
             }
         } else {
-            for(unsigned int i = 0; i < opNum; i++) {
+            for (unsigned int i = 0; i < opNum; i++) {
                 iterator++; //just advance the iterator so it points to the operations where we stopped before the edit
                 position++;
             }
         }
-	    if (iterator != qc->end() && ((*iterator)->getType() == qc::Measure || (*iterator)->getType() == qc::Reset)) {
-		    state.Set("nextIsIrreversible", Napi::Boolean::New(env, true));
-	    }
-	    if (iterator != qc->begin()) {
-		    auto testForMeasureIt = iterator;
-		    --testForMeasureIt;
-		    if ((*testForMeasureIt)->getType() == qc::Measure || (*testForMeasureIt)->getType() == qc::Reset) {
-			    state.Set("noGoingBack", Napi::Boolean::New(env, true));
-		    }
-	    }
+        if (iterator != qc->end() && ((*iterator)->getType() == qc::Measure || (*iterator)->getType() == qc::Reset)) {
+            state.Set("nextIsIrreversible", Napi::Boolean::New(env, true));
+        }
+        if (iterator != qc->begin()) {
+            auto testForMeasureIt = iterator;
+            --testForMeasureIt;
+            if ((*testForMeasureIt)->getType() == qc::Measure || (*testForMeasureIt)->getType() == qc::Reset) {
+                state.Set("noGoingBack", Napi::Boolean::New(env, true));
+            }
+        }
 
-    } else {    //sim needs to be initialized in some cases
-        if(sim.p != nullptr) {
+    } else { //sim needs to be initialized in some cases
+        if (sim.p != nullptr) {
             dd->decRef(sim);
         }
         sim = dd->makeZeroState(qc->getNqubits());
@@ -346,32 +346,33 @@ Napi::Value QDDVis::Load(const Napi::CallbackInfo& info) {
  */
 Napi::Value QDDVis::ToStart(const Napi::CallbackInfo& info) {
     Napi::Env env = info.Env();
-    if(!ready) {
+    if (!ready) {
         Napi::Error::New(env, "No algorithm loaded!").ThrowAsJavaScriptException();
         return Napi::Boolean::New(env, false);
     } else if (qc->empty()) {
         return Napi::Boolean::New(env, false);
     }
 
-    if(atInitial) return Napi::Boolean::New(env, false);  //nothing changed
+    if (atInitial)
+        return Napi::Boolean::New(env, false); //nothing changed
     else {
         try {
             dd->decRef(sim);
             sim = dd->makeZeroState(qc->getNqubits());
             dd->incRef(sim);
             atInitial = true;
-            atEnd = false; //now we are definitely not at the end (if there were no operation, so atInitial and atEnd could be true at the same time, if(qc1-empty)
+            atEnd     = false; //now we are definitely not at the end (if there were no operation, so atInitial and atEnd could be true at the same time, if(qc1-empty)
             // would already have returned
             iterator = qc->begin();
             position = 0;
             std::fill(measurements.begin(), measurements.end(), false);
 
-            return Napi::Boolean::New(env, true);   //something changed
+            return Napi::Boolean::New(env, true); //something changed
 
-        } catch(std::exception& e) {
+        } catch (std::exception& e) {
             std::cout << "Exception while going back to the start!" << std::endl;
             std::cout << e.what() << std::endl;
-            return Napi::Boolean::New(env, false);  //nothing changed
+            return Napi::Boolean::New(env, false); //nothing changed
         }
     }
 }
@@ -388,12 +389,12 @@ Napi::Value QDDVis::ToStart(const Napi::CallbackInfo& info) {
  * 			noGoingBack: true if the previous operation now is an irreversible operation
  */
 Napi::Value QDDVis::Prev(const Napi::CallbackInfo& info) {
-    Napi::Env env = info.Env();
-	Napi::Object state = Napi::Object::New(env);
-	state.Set("changed", Napi::Boolean::New(env, false));
-	state.Set("noGoingBack", Napi::Boolean::New(env, false));
+    Napi::Env    env   = info.Env();
+    Napi::Object state = Napi::Object::New(env);
+    state.Set("changed", Napi::Boolean::New(env, false));
+    state.Set("noGoingBack", Napi::Boolean::New(env, false));
 
-    if(!ready) {
+    if (!ready) {
         Napi::Error::New(env, "No algorithm loaded!").ThrowAsJavaScriptException();
         return state;
     } else if (qc->empty()) {
@@ -407,20 +408,20 @@ Napi::Value QDDVis::Prev(const Napi::CallbackInfo& info) {
     }
 
     try {
-        stepBack();     //go back to the start before the last processed operation
-	    state.Set("changed", Napi::Boolean::New(env, true));
+        stepBack(); //go back to the start before the last processed operation
+        state.Set("changed", Napi::Boolean::New(env, true));
 
-	    if (iterator != qc->begin()) {
-		    auto testForMeasureIt = iterator;
-		    --testForMeasureIt;
-		    if ((*testForMeasureIt)->getType() == qc::Measure || (*testForMeasureIt)->getType() == qc::Reset) {
-			    state.Set("noGoingBack", Napi::Boolean::New(env, true));
-		    }
-	    }
+        if (iterator != qc->begin()) {
+            auto testForMeasureIt = iterator;
+            --testForMeasureIt;
+            if ((*testForMeasureIt)->getType() == qc::Measure || (*testForMeasureIt)->getType() == qc::Reset) {
+                state.Set("noGoingBack", Napi::Boolean::New(env, true));
+            }
+        }
 
-	    return state;   //something changed
+        return state; //something changed
 
-    } catch(std::exception& e) {
+    } catch (std::exception& e) {
         std::cout << "Exception while getting the current operation {src: prev}!" << std::endl;
         std::cout << e.what() << std::endl;
         return state;
@@ -440,84 +441,82 @@ Napi::Value QDDVis::Prev(const Napi::CallbackInfo& info) {
  * 			parameter: object containing the measurement/reset parameters
  */
 Napi::Value QDDVis::Next(const Napi::CallbackInfo& info) {
-    Napi::Env env = info.Env();
-	Napi::Object state = Napi::Object::New(env);
-	state.Set("changed", Napi::Boolean::New(env, false));
-	state.Set("conductIrreversibleOperation", Napi::Boolean::New(env, false));
-	state.Set("nextIsIrreversible", Napi::Boolean::New(env, false));
+    Napi::Env    env   = info.Env();
+    Napi::Object state = Napi::Object::New(env);
+    state.Set("changed", Napi::Boolean::New(env, false));
+    state.Set("conductIrreversibleOperation", Napi::Boolean::New(env, false));
+    state.Set("nextIsIrreversible", Napi::Boolean::New(env, false));
 
-	if(!ready) {
+    if (!ready) {
         Napi::Error::New(env, "No algorithm loaded!").ThrowAsJavaScriptException();
         return state;
     } else if (qc->empty()) {
         return state;
     }
 
-    if(atInitial){
+    if (atInitial) {
         atInitial = false;
-    } else if(atEnd) {
+    } else if (atEnd) {
         return state; //we can't go any further ahead
     }
 
     try {
-	    state.Set("changed", Napi::Boolean::New(env, true));
+        state.Set("changed", Napi::Boolean::New(env, true));
 
-	    if ((*iterator)->getType() == qc::Reset) {
+        if ((*iterator)->getType() == qc::Reset) {
+            auto qubits        = (*iterator)->getTargets();
+            auto totalResets   = qubits.size();
+            auto qubitToReset  = qubits.front();
+            auto qubitsReset   = 0;
+            auto [pzero, pone] = getProbabilities(qubitToReset);
 
-		    auto qubits = (*iterator)->getTargets();
-		    auto totalResets = qubits.size();
-		    auto qubitToReset = qubits.front();
-		    auto qubitsReset = 0;
-		    auto [pzero, pone] = getProbabilities(qubitToReset);
+            Napi::Object reset = Napi::Object::New(env);
+            reset.Set("qubit", Napi::Number::New(env, qubitToReset));
+            reset.Set("pzero", Napi::Number::New(env, pzero));
+            reset.Set("pone", Napi::Number::New(env, pone));
+            reset.Set("count", Napi::Number::New(env, qubitsReset));
+            reset.Set("total", Napi::Number::New(env, static_cast<double>(totalResets)));
+            state.Set("parameter", reset);
+            state.Set("conductIrreversibleOperation", Napi::Boolean::New(env, true));
 
-		    Napi::Object reset = Napi::Object::New(env);
-		    reset.Set("qubit", Napi::Number::New(env, qubitToReset));
-		    reset.Set("pzero", Napi::Number::New(env, pzero));
-		    reset.Set("pone", Napi::Number::New(env, pone));
-		    reset.Set("count", Napi::Number::New(env, qubitsReset));
-		    reset.Set("total", Napi::Number::New(env, static_cast<double>(totalResets)));
-		    state.Set("parameter", reset);
-		    state.Set("conductIrreversibleOperation", Napi::Boolean::New(env, true));
+            iterator++; // advance iterator
+            position++;
+            if (iterator == qc->end()) { //qc1->end() is after the last operation in the iterator
+                atEnd = true;
+            }
+        } else if ((*iterator)->getType() == qc::Measure) {
+            auto qubits            = (*iterator)->getTargets();
+            auto cbits             = dynamic_cast<qc::NonUnitaryOperation*>(iterator->get())->getClassics();
+            auto totalMeasurements = qubits.size();
+            auto qubitToMeasure    = qubits.front();
+            auto cbitToStore       = cbits.front();
+            auto qubitsMeasured    = 0;
+            auto [pzero, pone]     = getProbabilities(qubitToMeasure);
 
-		    iterator++; // advance iterator
-		    position++;
-		    if (iterator == qc->end()) {    //qc1->end() is after the last operation in the iterator
-			    atEnd = true;
-		    }
-	    } else if ((*iterator)->getType() == qc::Measure) {
+            Napi::Object measurement = Napi::Object::New(env);
+            measurement.Set("qubit", Napi::Number::New(env, qubitToMeasure));
+            measurement.Set("pzero", Napi::Number::New(env, pzero));
+            measurement.Set("pone", Napi::Number::New(env, pone));
+            measurement.Set("cbit", Napi::Number::New(env, static_cast<double>(cbitToStore)));
+            measurement.Set("count", Napi::Number::New(env, qubitsMeasured));
+            measurement.Set("total", Napi::Number::New(env, static_cast<double>(totalMeasurements)));
+            state.Set("parameter", measurement);
+            state.Set("conductIrreversibleOperation", Napi::Boolean::New(env, true));
 
-			auto qubits = (*iterator)->getTargets();
-			auto cbits = dynamic_cast<qc::NonUnitaryOperation*>(iterator->get())->getClassics();
-			auto totalMeasurements = qubits.size();
-			auto qubitToMeasure = qubits.front();
-			auto cbitToStore = cbits.front();
-			auto qubitsMeasured = 0;
-			auto [pzero, pone] = getProbabilities(qubitToMeasure);
+            iterator++; // advance iterator
+            position++;
+            if (iterator == qc->end()) { //qc1->end() is after the last operation in the iterator
+                atEnd = true;
+            }
+        } else {
+            stepForward(); //process the next operation
+        }
 
-		    Napi::Object measurement = Napi::Object::New(env);
-		    measurement.Set("qubit", Napi::Number::New(env, qubitToMeasure));
-		    measurement.Set("pzero", Napi::Number::New(env, pzero));
-		    measurement.Set("pone", Napi::Number::New(env, pone));
-		    measurement.Set("cbit", Napi::Number::New(env, static_cast<double>(cbitToStore)));
-		    measurement.Set("count", Napi::Number::New(env, qubitsMeasured));
-		    measurement.Set("total", Napi::Number::New(env, static_cast<double>(totalMeasurements)));
-		    state.Set("parameter", measurement);
-		    state.Set("conductIrreversibleOperation", Napi::Boolean::New(env, true));
-
-		    iterator++; // advance iterator
-		    position++;
-		    if (iterator == qc->end()) {    //qc1->end() is after the last operation in the iterator
-			    atEnd = true;
-		    }
-	    } else {
-		    stepForward(); //process the next operation
-	    }
-
-	    if (iterator != qc->end() && ((*iterator)->getType() == qc::Measure || (*iterator)->getType() == qc::Reset)) {
-		    state.Set("nextIsIrreversible", Napi::Boolean::New(env, true));
-	    }
+        if (iterator != qc->end() && ((*iterator)->getType() == qc::Measure || (*iterator)->getType() == qc::Reset)) {
+            state.Set("nextIsIrreversible", Napi::Boolean::New(env, true));
+        }
         return state;
-    } catch(std::exception& e) {
+    } catch (std::exception& e) {
         std::cout << "Exception while getting the current operation {src: next}!" << std::endl;
         std::cout << e.what() << std::endl;
         return state;
@@ -535,43 +534,44 @@ Napi::Value QDDVis::Next(const Napi::CallbackInfo& info) {
  * 			barrier: true if a barrier was encountered
  */
 Napi::Value QDDVis::ToEnd(const Napi::CallbackInfo& info) {
-    Napi::Env env = info.Env();
-	Napi::Object state = Napi::Object::New(env);
-	state.Set("changed", Napi::Boolean::New(env, false));
-	state.Set("nextIsIrreversible", Napi::Boolean::New(env, false));
-	state.Set("barrier", Napi::Boolean::New(env, false));
+    Napi::Env    env   = info.Env();
+    Napi::Object state = Napi::Object::New(env);
+    state.Set("changed", Napi::Boolean::New(env, false));
+    state.Set("nextIsIrreversible", Napi::Boolean::New(env, false));
+    state.Set("barrier", Napi::Boolean::New(env, false));
 
-	if(!ready) {
+    if (!ready) {
         Napi::Error::New(env, "No algorithm loaded!").ThrowAsJavaScriptException();
         return state;
     } else if (qc->empty()) {
         return state;
     }
 
-    if(atEnd) return state; //nothing changed
+    if (atEnd)
+        return state; //nothing changed
     else {
-        atInitial = false;  //now we are definitely not at the beginning (if there were no operation, so atInitial and atEnd could be true at the same time, if(qc1-empty)
+        atInitial = false; //now we are definitely not at the beginning (if there were no operation, so atInitial and atEnd could be true at the same time, if(qc1-empty)
         // would already have returned
         try {
-	        state.Set("changed", Napi::Boolean::New(env, true));
-	        unsigned long long nops = 0;
-	        while (!atEnd) {
-		        if ((*iterator)->getType() == qc::Measure || (*iterator)->getType() == qc::Reset) {
-			        state.Set("nextIsIrreversible", Napi::Boolean::New(env, true));
-			        break;
-		        } else if ((*iterator)->getType() == qc::Barrier) {
-			        ++nops;
-			        stepForward(); //process the barrier
-			        state.Set("barrier", Napi::Boolean::New(env, true));
-			        break;
-		        } else {
-		        	++nops;
-			        stepForward(); //process the next operation
-		        }
-	        }
-	        state.Set("nops", Napi::Number::New(env, static_cast<double>(nops)));
-	        return state;
-        } catch(std::exception& e) {
+            state.Set("changed", Napi::Boolean::New(env, true));
+            unsigned long long nops = 0;
+            while (!atEnd) {
+                if ((*iterator)->getType() == qc::Measure || (*iterator)->getType() == qc::Reset) {
+                    state.Set("nextIsIrreversible", Napi::Boolean::New(env, true));
+                    break;
+                } else if ((*iterator)->getType() == qc::Barrier) {
+                    ++nops;
+                    stepForward(); //process the barrier
+                    state.Set("barrier", Napi::Boolean::New(env, true));
+                    break;
+                } else {
+                    ++nops;
+                    stepForward(); //process the next operation
+                }
+            }
+            state.Set("nops", Napi::Number::New(env, static_cast<double>(nops)));
+            return state;
+        } catch (std::exception& e) {
             std::cout << "Exception while going to the end!" << std::endl;
             std::cout << e.what() << std::endl;
             return state;
@@ -586,102 +586,104 @@ Napi::Value QDDVis::ToEnd(const Napi::CallbackInfo& info) {
  * @param info takes one parameter that determines to which position the iterator should point at after this call
  * @return true if the DD changed, false otherwise (nothing was done or an error occured)
  */
-Napi::Value QDDVis::ToLine(const Napi::CallbackInfo &info) {
-    Napi::Env env = info.Env();
+Napi::Value QDDVis::ToLine(const Napi::CallbackInfo& info) {
+    Napi::Env         env = info.Env();
     Napi::HandleScope scope(env);
-	Napi::Object state = Napi::Object::New(env);
-	state.Set("changed", Napi::Boolean::New(env, false));
-	state.Set("noGoingBack", Napi::Boolean::New(env, false));
-	state.Set("nextIsIrreversible", Napi::Boolean::New(env, false));
-	state.Set("reset", Napi::Boolean::New(env, false));
+    Napi::Object      state = Napi::Object::New(env);
+    state.Set("changed", Napi::Boolean::New(env, false));
+    state.Set("noGoingBack", Napi::Boolean::New(env, false));
+    state.Set("nextIsIrreversible", Napi::Boolean::New(env, false));
+    state.Set("reset", Napi::Boolean::New(env, false));
 
-	//check if the correct parameters have been passed
-    if(info.Length() < 1) {
+    //check if the correct parameters have been passed
+    if (info.Length() < 1) {
         Napi::RangeError::New(env, "Need 1 (unsigned int) argument!").ThrowAsJavaScriptException();
         return state;
     }
-    if (!info[0].IsNumber()) {  //line number/position
+    if (!info[0].IsNumber()) { //line number/position
         Napi::TypeError::New(env, "arg1: unsigned int expected!").ThrowAsJavaScriptException();
         return state;
     }
 
     unsigned int param = (unsigned int)info[0].As<Napi::Number>();
-    if(param > qc->getNops()) param = qc->getNops();    //we can't go further than to the end
+    if (param > qc->getNops()) param = qc->getNops(); //we can't go further than to the end
     const unsigned int targetPos = param;
 
     try {
-	    if (iterator != qc->begin()) {
-		    auto testForMeasureIt = iterator;
-		    --testForMeasureIt;
-		    if ((*testForMeasureIt)->getType() == qc::Measure || (*testForMeasureIt)->getType() == qc::Reset) {
-			    state.Set("noGoingBack", Napi::Boolean::New(env, true));
-		    }
-	    }
-	    if (iterator != qc->end() && ((*iterator)->getType() == qc::Measure || (*iterator)->getType() == qc::Reset)) {
-		    state.Set("nextIsIrreversible", Napi::Boolean::New(env, true));
-	    }
-        if(position == targetPos) return state;   //nothing changed
+        if (iterator != qc->begin()) {
+            auto testForMeasureIt = iterator;
+            --testForMeasureIt;
+            if ((*testForMeasureIt)->getType() == qc::Measure || (*testForMeasureIt)->getType() == qc::Reset) {
+                state.Set("noGoingBack", Napi::Boolean::New(env, true));
+            }
+        }
+        if (iterator != qc->end() && ((*iterator)->getType() == qc::Measure || (*iterator)->getType() == qc::Reset)) {
+            state.Set("nextIsIrreversible", Napi::Boolean::New(env, true));
+        }
+        if (position == targetPos) return state; //nothing changed
 
-	    unsigned long long nops = 0;
-	    if (targetPos < position) {
-		    unsigned int distanceFromPosition = position - targetPos;
-		    // if target position is closer to start as to current position computation can be restarted
-	        if( targetPos < distanceFromPosition) {
-		        state.Set("reset", Napi::Boolean::New(env, true));
-		        state.Set("changed", Napi::Boolean::New(env, true));
-		        state.Set("nextIsIrreversible", Napi::Boolean::New(env, false));
-		        state.Set("noGoingBack", Napi::Boolean::New(env, true));
+        unsigned long long nops = 0;
+        if (targetPos < position) {
+            unsigned int distanceFromPosition = position - targetPos;
+            // if target position is closer to start as to current position computation can be restarted
+            if (targetPos < distanceFromPosition) {
+                state.Set("reset", Napi::Boolean::New(env, true));
+                state.Set("changed", Napi::Boolean::New(env, true));
+                state.Set("nextIsIrreversible", Napi::Boolean::New(env, false));
+                state.Set("noGoingBack", Napi::Boolean::New(env, true));
 
-		        dd->decRef(sim);
-		        sim = dd->makeZeroState(qc->getNqubits());
-		        dd->incRef(sim);
-		        atInitial = true;
-		        atEnd = false;
-		        iterator = qc->begin();
-		        position = 0;
-		        std::fill(measurements.begin(), measurements.end(), false);
-		        if ((*iterator)->getType() == qc::Measure || (*iterator)->getType() == qc::Reset) {
-			        state.Set("nextIsIrreversible", Napi::Boolean::New(env, true));
-		        }
+                dd->decRef(sim);
+                sim = dd->makeZeroState(qc->getNqubits());
+                dd->incRef(sim);
+                atInitial = true;
+                atEnd     = false;
+                iterator  = qc->begin();
+                position  = 0;
+                std::fill(measurements.begin(), measurements.end(), false);
+                if ((*iterator)->getType() == qc::Measure || (*iterator)->getType() == qc::Reset) {
+                    state.Set("nextIsIrreversible", Napi::Boolean::New(env, true));
+                }
             } else {
-		        state.Set("noGoingBack", Napi::Boolean::New(env, false));
-		        while(position > targetPos) {
-			        auto testForMeasureIt = iterator;
-			        --testForMeasureIt;
-			        if ((*testForMeasureIt)->getType() == qc::Measure || (*testForMeasureIt)->getType() == qc::Reset) {
-				        state.Set("noGoingBack", Napi::Boolean::New(env, true));
-				        break;
-			        }
-					++nops;
-			        stepBack();
-			        state.Set("changed", Napi::Boolean::New(env, true));
-			        state.Set("nextIsIrreversible", Napi::Boolean::New(env, false));
-		        }
-        	}
+                state.Set("noGoingBack", Napi::Boolean::New(env, false));
+                while (position > targetPos) {
+                    auto testForMeasureIt = iterator;
+                    --testForMeasureIt;
+                    if ((*testForMeasureIt)->getType() == qc::Measure || (*testForMeasureIt)->getType() == qc::Reset) {
+                        state.Set("noGoingBack", Napi::Boolean::New(env, true));
+                        break;
+                    }
+                    ++nops;
+                    stepBack();
+                    state.Set("changed", Napi::Boolean::New(env, true));
+                    state.Set("nextIsIrreversible", Napi::Boolean::New(env, false));
+                }
+            }
         }
 
-	    while (position < targetPos) {
-		    if ((*iterator)->getType() == qc::Measure || (*iterator)->getType() == qc::Reset) {
-			    state.Set("nextIsIrreversible", Napi::Boolean::New(env, true));
-			    break;
-		    } else {
-			    ++nops;
-			    stepForward(); //process the next operation
-		    }
-		    state.Set("changed", Napi::Boolean::New(env, true));
-		    state.Set("noGoingBack", Napi::Boolean::New(env, false));
-	    }
-	    state.Set("nops", Napi::Number::New(env, static_cast<double>(nops)));
+        while (position < targetPos) {
+            if ((*iterator)->getType() == qc::Measure || (*iterator)->getType() == qc::Reset) {
+                state.Set("nextIsIrreversible", Napi::Boolean::New(env, true));
+                break;
+            } else {
+                ++nops;
+                stepForward(); //process the next operation
+            }
+            state.Set("changed", Napi::Boolean::New(env, true));
+            state.Set("noGoingBack", Napi::Boolean::New(env, false));
+        }
+        state.Set("nops", Napi::Number::New(env, static_cast<double>(nops)));
 
         atInitial = false;
-        atEnd = false;
-        if(position == 0) atInitial = true;
-        else if(position == qc->getNops()) atEnd = true;
+        atEnd     = false;
+        if (position == 0)
+            atInitial = true;
+        else if (position == qc->getNops())
+            atEnd = true;
 
-        return state;   //something changed
+        return state; //something changed
 
-    } catch(std::exception& e) {
-        std::string msg = "Exception while going to line ";// + position + " to " + targetPos;
+    } catch (std::exception& e) {
+        std::string msg = "Exception while going to line "; // + position + " to " + targetPos;
         //msg += position + " to " + targetPos;
         //msg.append(position);
         //msg.append(" to ");
@@ -700,9 +702,9 @@ Napi::Value QDDVis::ToLine(const Napi::CallbackInfo &info) {
  * @return a string describing the current state of the simulation as DD in the .dot-format
  */
 Napi::Value QDDVis::GetDD(const Napi::CallbackInfo& info) {
-    Napi::Env env = info.Env();
-	Napi::Object state = Napi::Object::New(env);
-    if(!ready) {
+    Napi::Env    env   = info.Env();
+    Napi::Object state = Napi::Object::New(env);
+    if (!ready) {
         Napi::Error::New(env, "No algorithm loaded!").ThrowAsJavaScriptException();
         return Napi::String::New(env, "-1");
     }
@@ -712,18 +714,18 @@ Napi::Value QDDVis::GetDD(const Napi::CallbackInfo& info) {
         dd::toDot(sim, ss, this->showColors, this->showEdgeLabels, this->showClassic);
         std::string str = ss.str();
         state.Set("dot", Napi::String::New(env, str));
-	    state.Set("amplitudes", Napi::Float32Array::New(env, 0));
-	    if (qc->getNqubits() <= MAX_QUBITS_FOR_AMPLITUDES) {
-	    	auto amplitudes = Napi::Float32Array::New(env, 1ull<<(qc->getNqubits()+1));
-		    calculateAmplitudes(amplitudes);
-		    state.Set("amplitudes", amplitudes);
-	    }
+        state.Set("amplitudes", Napi::Float32Array::New(env, 0));
+        if (qc->getNqubits() <= MAX_QUBITS_FOR_AMPLITUDES) {
+            auto amplitudes = Napi::Float32Array::New(env, 1ull << (qc->getNqubits() + 1));
+            calculateAmplitudes(amplitudes);
+            state.Set("amplitudes", amplitudes);
+        }
         return state;
 
-    } catch(std::exception& e) {
+    } catch (std::exception& e) {
         std::cout << "Exception while getting the DD: " << e.what() << std::endl;
         std::cout << "The values of the Flags are: " << this->showColors << ", " << this->showEdgeLabels << ", " << this->showClassic << std::endl;
-        std::string err = "Invalid getDD()-call! ";// + e.what();
+        std::string err = "Invalid getDD()-call! "; // + e.what();
         Napi::Error::New(env, err).ThrowAsJavaScriptException();
         return Napi::String::New(env, "-1");
     }
@@ -737,31 +739,31 @@ Napi::Value QDDVis::GetDD(const Napi::CallbackInfo& info) {
 void QDDVis::UpdateExportOptions(const Napi::CallbackInfo& info) {
     Napi::Env env = info.Env();
     //check if the correct parameters have been passed
-    if(info.Length() != 3) {
+    if (info.Length() != 3) {
         Napi::RangeError::New(env, "Need 3 (bool, bool, bool) arguments!").ThrowAsJavaScriptException();
         return;
     }
-    if (!info[0].IsBoolean()) {  //colored
+    if (!info[0].IsBoolean()) { //colored
         Napi::TypeError::New(env, "arg1: Boolean expected!").ThrowAsJavaScriptException();
         return;
     }
-    if (!info[1].IsBoolean()) {  //edgeLabels
+    if (!info[1].IsBoolean()) { //edgeLabels
         Napi::TypeError::New(env, "arg2: Boolean expected!").ThrowAsJavaScriptException();
         return;
     }
-    if (!info[2].IsBoolean()) {  //classic
+    if (!info[2].IsBoolean()) { //classic
         Napi::TypeError::New(env, "arg3: Boolean expected!").ThrowAsJavaScriptException();
         return;
     }
 
-    this->showColors = (bool)info[0].As<Napi::Boolean>();
+    this->showColors     = (bool)info[0].As<Napi::Boolean>();
     this->showEdgeLabels = (bool)info[1].As<Napi::Boolean>();
-    this->showClassic = (bool)info[2].As<Napi::Boolean>();
+    this->showClassic    = (bool)info[2].As<Napi::Boolean>();
     //std::cout << "Updated the values of the Flags to: " << this->showColors << ", " << this->showEdgeLabels << ", " << this->showClassic << std::endl;
 }
 
 Napi::Value QDDVis::GetExportOptions(const Napi::CallbackInfo& info) {
-    Napi::Env env = info.Env();
+    Napi::Env    env   = info.Env();
     Napi::Object state = Napi::Object::New(env);
 
     state.Set("colored", this->showColors);
@@ -785,115 +787,114 @@ void QDDVis::Unready([[maybe_unused]] const Napi::CallbackInfo& info) {
 }
 
 Napi::Value QDDVis::ConductIrreversibleOperation(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
 
-	Napi::Env env = info.Env();
+    if (info.Length() < 1) {
+        Napi::RangeError::New(env, "Need 1 Object(int, double, double, string, int, int, (int)) argument!").ThrowAsJavaScriptException();
+    }
+    if (!info[0].IsObject()) {
+        Napi::TypeError::New(env, "Need 1 Object(int, double, double, string, int, int, (int)) argument!").ThrowAsJavaScriptException();
+    }
+    const auto obj = info[0].ToObject();
+    if (!obj.Has("qubit")) {
+        Napi::TypeError::New(env, "Expected qubit").ThrowAsJavaScriptException();
+    } else if (!obj.Get("qubit").IsNumber()) {
+        Napi::TypeError::New(env, "qubit: Number expected!").ThrowAsJavaScriptException();
+    }
 
-	if (info.Length() < 1) {
-		Napi::RangeError::New(env, "Need 1 Object(int, double, double, string, int, int, (int)) argument!").ThrowAsJavaScriptException();
-	}
-	if (!info[0].IsObject()) {
-		Napi::TypeError::New(env, "Need 1 Object(int, double, double, string, int, int, (int)) argument!").ThrowAsJavaScriptException();
-	}
-	const auto obj = info[0].ToObject();
-	if (!obj.Has("qubit")) {
-		Napi::TypeError::New(env, "Expected qubit").ThrowAsJavaScriptException();
-	} else if (!obj.Get("qubit").IsNumber()) {
-		Napi::TypeError::New(env, "qubit: Number expected!").ThrowAsJavaScriptException();
-	}
+    if (!obj.Has("pzero")) {
+        Napi::TypeError::New(env, "Expected probability for 0").ThrowAsJavaScriptException();
+    } else if (!obj.Get("pzero").IsNumber()) {
+        Napi::TypeError::New(env, "pzero: Number expected!").ThrowAsJavaScriptException();
+    }
 
-	if (!obj.Has("pzero")) {
-		Napi::TypeError::New(env, "Expected probability for 0").ThrowAsJavaScriptException();
-	} else if (!obj.Get("pzero").IsNumber()) {
-		Napi::TypeError::New(env, "pzero: Number expected!").ThrowAsJavaScriptException();
-	}
+    if (!obj.Has("pone")) {
+        Napi::TypeError::New(env, "Expected probability for 1").ThrowAsJavaScriptException();
+    } else if (!obj.Get("pone").IsNumber()) {
+        Napi::TypeError::New(env, "pone: Number expected!").ThrowAsJavaScriptException();
+    }
 
-	if (!obj.Has("pone")) {
-		Napi::TypeError::New(env, "Expected probability for 1").ThrowAsJavaScriptException();
-	} else if (!obj.Get("pone").IsNumber()) {
-		Napi::TypeError::New(env, "pone: Number expected!").ThrowAsJavaScriptException();
-	}
+    if (!obj.Has("classicalValueToMeasure")) {
+        Napi::TypeError::New(env, "Expected desired outcome").ThrowAsJavaScriptException();
+    } else if (!obj.Get("classicalValueToMeasure").IsString()) {
+        Napi::TypeError::New(env, "classicalValueToMeasure: String expected!").ThrowAsJavaScriptException();
+    }
 
-	if (!obj.Has("classicalValueToMeasure")) {
-		Napi::TypeError::New(env, "Expected desired outcome").ThrowAsJavaScriptException();
-	} else if (!obj.Get("classicalValueToMeasure").IsString()) {
-		Napi::TypeError::New(env, "classicalValueToMeasure: String expected!").ThrowAsJavaScriptException();
-	}
+    if (!obj.Has("count")) {
+        Napi::TypeError::New(env, "Expected qubits already measured").ThrowAsJavaScriptException();
+    } else if (!obj.Get("count").IsNumber()) {
+        Napi::TypeError::New(env, "count: Number expected!").ThrowAsJavaScriptException();
+    }
 
-	if (!obj.Has("count")) {
-		Napi::TypeError::New(env, "Expected qubits already measured").ThrowAsJavaScriptException();
-	} else if (!obj.Get("count").IsNumber()) {
-		Napi::TypeError::New(env, "count: Number expected!").ThrowAsJavaScriptException();
-	}
+    if (!obj.Has("total")) {
+        Napi::TypeError::New(env, "Expected total qubits to measure").ThrowAsJavaScriptException();
+    } else if (!obj.Get("total").IsNumber()) {
+        Napi::TypeError::New(env, "total: Number expected!").ThrowAsJavaScriptException();
+    }
 
-	if (!obj.Has("total")) {
-		Napi::TypeError::New(env, "Expected total qubits to measure").ThrowAsJavaScriptException();
-	} else if (!obj.Get("total").IsNumber()) {
-		Napi::TypeError::New(env, "total: Number expected!").ThrowAsJavaScriptException();
-	}
+    auto qubit                   = static_cast<dd::Qubit>(obj.Get("qubit").As<Napi::Number>().Int64Value());
+    auto pzero                   = obj.Get("pzero").As<Napi::Number>().DoubleValue();
+    auto pone                    = obj.Get("pone").As<Napi::Number>().DoubleValue();
+    auto classicalValueToMeasure = obj.Get("classicalValueToMeasure").As<Napi::String>().Utf8Value();
+    auto count                   = obj.Get("count").As<Napi::Number>().Int64Value();
+    auto total                   = obj.Get("total").As<Napi::Number>().Int64Value();
 
-	auto qubit = static_cast<dd::Qubit>(obj.Get("qubit").As<Napi::Number>().Int64Value());
-	auto pzero = obj.Get("pzero").As<Napi::Number>().DoubleValue();
-	auto pone = obj.Get("pone").As<Napi::Number>().DoubleValue();
-	auto classicalValueToMeasure = obj.Get("classicalValueToMeasure").As<Napi::String>().Utf8Value();
-	auto count = obj.Get("count").As<Napi::Number>().Int64Value();
-	auto total = obj.Get("total").As<Napi::Number>().Int64Value();
+    bool isReset = false;
+    if (!obj.Has("cbit")) {
+        isReset = true;
+    } else if (!obj.Get("cbit").IsNumber()) {
+        Napi::TypeError::New(env, "cbit: Number expected!").ThrowAsJavaScriptException();
+    }
 
-	bool isReset = false;
-	if (!obj.Has("cbit")) {
-		isReset = true;
-	} else if (!obj.Get("cbit").IsNumber()) {
-		Napi::TypeError::New(env, "cbit: Number expected!").ThrowAsJavaScriptException();
-	}
+    // return value
+    Napi::Object state = Napi::Object::New(env);
+    state.Set("finished", Napi::Boolean::New(env, false));
+    Napi::Object parameter = Napi::Object::New(env);
 
-	// return value
-	Napi::Object state = Napi::Object::New(env);
-	state.Set("finished", Napi::Boolean::New(env, false));
-	Napi::Object parameter = Napi::Object::New(env);
+    if (isReset) {
+        // reset operation
+        if (classicalValueToMeasure == "0") {
+            measureQubit(qubit, false, pzero, pone);
+        } else if (classicalValueToMeasure == "1") {
+            measureQubit(qubit, true, pzero, pone);
+            //apply x operation to reset to |0>
+            auto tmp = dd->multiply(qc::StandardOperation(qc->getNqubits(), qubit, qc::X).getDD(dd), sim);
+            dd->incRef(tmp);
+            dd->decRef(sim);
+            sim = tmp;
 
-	if (isReset) {
-		// reset operation
-		if (classicalValueToMeasure == "0") {
-			measureQubit(qubit, false, pzero, pone);
-		} else if (classicalValueToMeasure == "1") {
-			measureQubit(qubit, true, pzero, pone);
-			//apply x operation to reset to |0>
-			auto tmp = dd->multiply(qc::StandardOperation(qc->getNqubits(), qubit, qc::X).getDD(dd), sim);
-			dd->incRef(tmp);
-			dd->decRef(sim);
-			sim = tmp;
+            dd->garbageCollect();
+        } else {
+            // do something in case operation is cancelled
+        }
+    } else {
+        // get target classical bit
+        auto cbit = obj.Get("cbit").As<Napi::Number>().Int64Value();
+        if (classicalValueToMeasure != "none") {
+            bool measureOne = (classicalValueToMeasure == "1");
+            measureQubit(qubit, measureOne, pzero, pone);
+            measurements[cbit] = measureOne;
+        }
+        cbit++;
+        parameter.Set("cbit", Napi::Number::New(env, static_cast<double>(cbit)));
+    }
 
-			dd->garbageCollect();
-		} else {
-			// do something in case operation is cancelled
-		}
-	} else {
-		// get target classical bit
-		auto cbit = obj.Get("cbit").As<Napi::Number>().Int64Value();
-		if (classicalValueToMeasure != "none") {
-			bool measureOne = (classicalValueToMeasure == "1");
-			measureQubit(qubit, measureOne, pzero, pone);
-			measurements[cbit] = measureOne;
-		}
-		cbit++;
-		parameter.Set("cbit", Napi::Number::New(env, static_cast<double>(cbit)));
-	}
+    count++;
+    if (count == total) {
+        state.Set("finished", Napi::Boolean::New(env, true));
+        return state;
+    }
 
-	count++;
-	if (count == total) {
-		state.Set("finished", Napi::Boolean::New(env, true));
-		return state;
-	}
+    // next qubit
+    qubit++;
+    std::tie(pzero, pone) = getProbabilities(qubit);
 
-	// next qubit
-	qubit++;
-	std::tie(pzero, pone) = getProbabilities(qubit);
+    parameter.Set("qubit", Napi::Number::New(env, qubit));
+    parameter.Set("pzero", Napi::Number::New(env, pzero));
+    parameter.Set("pone", Napi::Number::New(env, pone));
+    parameter.Set("count", Napi::Number::New(env, static_cast<double>(count)));
+    parameter.Set("total", Napi::Number::New(env, static_cast<double>(total)));
+    state.Set("parameter", parameter);
 
-	parameter.Set("qubit", Napi::Number::New(env, qubit));
-	parameter.Set("pzero", Napi::Number::New(env, pzero));
-	parameter.Set("pone", Napi::Number::New(env, pone));
-	parameter.Set("count", Napi::Number::New(env, static_cast<double>(count)));
-	parameter.Set("total", Napi::Number::New(env, static_cast<double>(total)));
-	state.Set("parameter", parameter);
-
-	return state;
+    return state;
 }

--- a/cpp/module/QDDVis.h
+++ b/cpp/module/QDDVis.h
@@ -58,9 +58,10 @@ private:
     bool              atEnd     = false; // whether we currently visualize the end of the given circuit
 
     //options for the DD export
-    bool showColors     = true;
-    bool showEdgeLabels = true;
-    bool showClassic    = false;
+    bool showColors          = true;
+    bool showEdgeLabels      = true;
+    bool showClassic         = false;
+    bool usePolarCoordinates = true;
 };
 
 #endif

--- a/cpp/module/QDDVis.h
+++ b/cpp/module/QDDVis.h
@@ -6,62 +6,61 @@
 #ifndef QDDVIS_H
 #define QDDVIS_H
 
-#include <napi.h>
-#include <string>
-#include <iostream>
-#include <string>
-#include <memory>
-#include <queue>
-
 #include "QuantumComputation.hpp"
 
-class QDDVis : public Napi::ObjectWrap<QDDVis> {
-    public:
-        static Napi::Object Init(Napi::Env evn, Napi::Object exports);
-        explicit QDDVis(const Napi::CallbackInfo& info);
+#include <iostream>
+#include <memory>
+#include <napi.h>
+#include <queue>
+#include <string>
 
-    private:
-        static inline Napi::FunctionReference constructor;
+class QDDVis: public Napi::ObjectWrap<QDDVis> {
+public:
+    static Napi::Object Init(Napi::Env evn, Napi::Object exports);
+    explicit QDDVis(const Napi::CallbackInfo& info);
 
-        static constexpr unsigned short MAX_QUBITS_FOR_AMPLITUDES = 9;
-        //"private" methods
-        void stepForward();
-        void stepBack();
-        [[nodiscard]] std::pair<dd::fp, dd::fp> getProbabilities(dd::Qubit qubitIdx) const;
-        void measureQubit(dd::Qubit qubitIdx, bool measureOne, dd::fp pzero, dd::fp pone);
-        void calculateAmplitudes(Napi::Float32Array& amplitudes);
+private:
+    static inline Napi::FunctionReference constructor;
 
-        //exported ("public") methods       - return type must be Napi::Value or void!
-        Napi::Value Load(const Napi::CallbackInfo& info);
-        Napi::Value ToStart(const Napi::CallbackInfo& info);
-        Napi::Value Next(const Napi::CallbackInfo& info);
-        Napi::Value Prev(const Napi::CallbackInfo& info);
-        Napi::Value ToEnd(const Napi::CallbackInfo& info);
-        Napi::Value ToLine(const Napi::CallbackInfo& info);
-        Napi::Value GetDD(const Napi::CallbackInfo& info);
-        void UpdateExportOptions(const Napi::CallbackInfo& info);
-        Napi::Value GetExportOptions(const Napi::CallbackInfo& info);
-        Napi::Value IsReady(const Napi::CallbackInfo& info);
-        void Unready(const Napi::CallbackInfo& info);
-		Napi::Value ConductIrreversibleOperation(const Napi::CallbackInfo& info);
+    static constexpr unsigned short MAX_QUBITS_FOR_AMPLITUDES = 9;
+    //"private" methods
+    void                                    stepForward();
+    void                                    stepBack();
+    [[nodiscard]] std::pair<dd::fp, dd::fp> getProbabilities(dd::Qubit qubitIdx) const;
+    void                                    measureQubit(dd::Qubit qubitIdx, bool measureOne, dd::fp pzero, dd::fp pone);
+    void                                    calculateAmplitudes(Napi::Float32Array& amplitudes);
 
-        //fields
-        std::unique_ptr<dd::Package> dd;
-        std::unique_ptr<qc::QuantumComputation> qc;
-        qc::VectorDD sim{};
+    //exported ("public") methods       - return type must be Napi::Value or void!
+    Napi::Value Load(const Napi::CallbackInfo& info);
+    Napi::Value ToStart(const Napi::CallbackInfo& info);
+    Napi::Value Next(const Napi::CallbackInfo& info);
+    Napi::Value Prev(const Napi::CallbackInfo& info);
+    Napi::Value ToEnd(const Napi::CallbackInfo& info);
+    Napi::Value ToLine(const Napi::CallbackInfo& info);
+    Napi::Value GetDD(const Napi::CallbackInfo& info);
+    void        UpdateExportOptions(const Napi::CallbackInfo& info);
+    Napi::Value GetExportOptions(const Napi::CallbackInfo& info);
+    Napi::Value IsReady(const Napi::CallbackInfo& info);
+    void        Unready(const Napi::CallbackInfo& info);
+    Napi::Value ConductIrreversibleOperation(const Napi::CallbackInfo& info);
 
-        std::vector<std::unique_ptr<qc::Operation>>::iterator iterator{};
-        unsigned int position = 0;  //current position of the iterator
+    //fields
+    std::unique_ptr<dd::Package>            dd;
+    std::unique_ptr<qc::QuantumComputation> qc;
+    qc::VectorDD                            sim{};
 
-        std::vector<bool> measurements{};
-        bool ready = false;     //true if a valid algorithm is imported, false otherwise
-        bool atInitial = true; //whether we currently visualize the initial state or not
-        bool atEnd = false; // whether we currently visualize the end of the given circuit
+    std::vector<std::unique_ptr<qc::Operation>>::iterator iterator{};
+    unsigned int                                          position = 0; //current position of the iterator
 
-        //options for the DD export
-        bool showColors = true;
-        bool showEdgeLabels = true;
-        bool showClassic = false;
+    std::vector<bool> measurements{};
+    bool              ready     = false; //true if a valid algorithm is imported, false otherwise
+    bool              atInitial = true;  //whether we currently visualize the initial state or not
+    bool              atEnd     = false; // whether we currently visualize the end of the given circuit
+
+    //options for the DD export
+    bool showColors     = true;
+    bool showEdgeLabels = true;
+    bool showClassic    = false;
 };
 
 #endif

--- a/cpp/module/module.cpp
+++ b/cpp/module/module.cpp
@@ -3,9 +3,10 @@
  * See file README.md or go to http://iic.jku.at/eda/research/quantum/ for more information.
  */
 
-#include <napi.h>
-#include "QDDVis.h"
 #include "QDDVer.h"
+#include "QDDVis.h"
+
+#include <napi.h>
 
 Napi::Object InitAll(Napi::Env env, Napi::Object exports) {
     exports = QDDVis::Init(env, exports);

--- a/cpp/sample_qasm/Graph State (4 qubits).qasm
+++ b/cpp/sample_qasm/Graph State (4 qubits).qasm
@@ -1,0 +1,24 @@
+OPENQASM 2.0;
+include "qelib1.inc";
+
+// Consider the only 3-regular graph on 4 vertices:
+// 0 -- 1
+// | >< |
+// 2 -- 3
+
+qreg q[4];
+creg c[4];
+
+// initialize all qubits in |+> state
+h q;
+barrier q;
+
+// apply controlled-Z operations for every edge
+cz q[3], q[2];
+cz q[3], q[1];
+cz q[3], q[0];
+cz q[2], q[1];
+cz q[2], q[0];
+cz q[1], q[0];
+
+measure q -> c;

--- a/cpp/sample_qasm/Graph State (6 qubits).qasm
+++ b/cpp/sample_qasm/Graph State (6 qubits).qasm
@@ -1,0 +1,33 @@
+OPENQASM 2.0;
+include "qelib1.inc";
+
+// Consider the following 3-regular graph on 6 vertices:
+//    0 -- 1
+//   / \  / \
+//  5 ----- 2
+//   \ /  \ /
+//    4 -- 3
+
+qreg q[6];
+creg c[6];
+
+// initialize all qubits in |+> state
+h q;
+barrier q;
+
+// apply controlled-Z operations for every edge
+cz q[5], q[4];
+cz q[5], q[2];
+cz q[5], q[0];
+
+cz q[4], q[3];
+cz q[4], q[1];
+
+cz q[3], q[2];
+cz q[3], q[0];
+
+cz q[2], q[1];
+
+cz q[1], q[0];
+
+measure q -> c;

--- a/cpp/sample_qasm/Grover (3 qubits).qasm
+++ b/cpp/sample_qasm/Grover (3 qubits).qasm
@@ -8,11 +8,10 @@ creg c[2];
 // initialization
 h q;
 x flag;
-h flag;
 barrier q;
 
 // oracle: mark target state |11>
-ccx q[0], q[1], flag;
+ccz q[0], q[1], flag;
 barrier q;
 
 // diffusion

--- a/cpp/sample_qasm/Grover (4 qubits).qasm
+++ b/cpp/sample_qasm/Grover (4 qubits).qasm
@@ -3,7 +3,7 @@ include "qelib1.inc";
 
 gate oracle q0, q1, q2, flag {
     // mark target state |111>
-    mcx q0, q1, q2, flag;
+    mcphase(pi) q0, q1, q2, flag;
 }
 
 gate diffusion q0, q1, q2 {
@@ -23,7 +23,6 @@ creg c[3];
 // initialization
 h q;
 x flag;
-h flag;
 barrier q;
 
 oracle q[0], q[1], q[2], flag;

--- a/cpp/sample_qasm/Grover (5 qubits).qasm
+++ b/cpp/sample_qasm/Grover (5 qubits).qasm
@@ -3,7 +3,7 @@ include "qelib1.inc";
 
 gate oracle q0, q1, q2, q3, flag {
     // mark target state |1111>
-    mcx q0, q1, q2, q3, flag;
+    mcphase(pi) q0, q1, q2, q3, flag;
 }
 
 gate diffusion q0, q1, q2, q3 {
@@ -23,7 +23,6 @@ creg c[4];
 // initialization
 h q;
 x flag;
-h flag;
 barrier q;
 
 oracle q[0], q[1], q[2], q[3], flag;

--- a/cpp/sample_qasm/Iterative QPE 3bit (2 qubits).qasm
+++ b/cpp/sample_qasm/Iterative QPE 3bit (2 qubits).qasm
@@ -1,0 +1,43 @@
+OPENQASM 2.0;
+include "qelib1.inc";
+
+// iteratively estimating the phase of U=p(3pi/8) with 3-bit precision
+// we seek theta=3/16=0.0011_2, which is not exactly representable using 3 bits
+// the best we can expect is high probabilities for 0.c_2 c_1 c_0 = 001 and 010
+
+// counting register
+qreg q[1];
+
+// eigenstate register
+qreg psi[1];
+
+// classical registers
+creg c[3];
+
+// initialize eigenstate psi = |1>
+x psi;
+barrier psi;
+
+// start by computing LSB c_0
+h q;
+cp(4 * (3*pi/8)) psi, q;
+h q;
+measure q[0] -> c[0];
+
+// reset counting qubit and compute middle bit c_1
+reset q;
+h q;
+cp(2 * (3*pi/8)) psi, q;
+if (c == 1) p(-pi/2) q;
+h q;
+measure q[0] -> c[1];
+
+// reset counting qubit and compute MSB c_2
+reset q;
+h q;
+cp(1 * (3*pi/8)) psi, q;
+if (c == 1) p(1 * -pi/4) q;
+if (c == 2) p(2 * -pi/4) q;
+if (c == 3) p(3 * -pi/4) q;
+h q;
+measure q[0] -> c[2];

--- a/cpp/sample_qasm/Iterative QPE 4bit (2 qubits).qasm
+++ b/cpp/sample_qasm/Iterative QPE 4bit (2 qubits).qasm
@@ -1,0 +1,57 @@
+OPENQASM 2.0;
+include "qelib1.inc";
+
+// iteratively estimating the phase of U=p(3pi/8) with 4-bit precision
+// we seek theta=3/16=0.0011_2, which is exactly representable using 4 bits
+// thus we expect to measure 0.c_3 c_2 c_1 c_0 = 0011 with certainty
+
+// counting register
+qreg q[1];
+
+// eigenstate register
+qreg psi[1];
+
+// classical registers
+creg c[4];
+
+// initialize eigenstate psi = |1>
+x psi;
+barrier psi;
+
+// start by computing LSB c_0
+h q;
+cp(8 * (3*pi/8)) psi, q;
+h q;
+measure q[0] -> c[0];
+
+// reset counting qubit and compute next bit c_1
+reset q;
+h q;
+cp(4 * (3*pi/8)) psi, q;
+if (c == 1) p(-pi/2) q;
+h q;
+measure q[0] -> c[1];
+
+// reset counting qubit and compute next bit c_2
+reset q;
+h q;
+cp(2 * (3*pi/8)) psi, q;
+if (c == 1) p(1 * -pi/4) q;
+if (c == 2) p(2 * -pi/4) q;
+if (c == 3) p(3 * -pi/4) q;
+h q;
+measure q[0] -> c[2];
+
+// reset counting qubit and compute MSB c_3
+reset q;
+h q;
+cp(1 * (3*pi/8)) psi, q;
+if (c == 1) p(1 * -pi/8) q;
+if (c == 2) p(2 * -pi/8) q;
+if (c == 3) p(3 * -pi/8) q;
+if (c == 4) p(4 * -pi/8) q;
+if (c == 5) p(5 * -pi/8) q;
+if (c == 6) p(6 * -pi/8) q;
+if (c == 7) p(7 * -pi/8) q;
+h q;
+measure q[0] -> c[3];

--- a/cpp/sample_qasm/Quantum Phase Estimation (3 qubits).qasm
+++ b/cpp/sample_qasm/Quantum Phase Estimation (3 qubits).qasm
@@ -38,6 +38,4 @@ cp(-pi/2) q[2], q[1];
 h q[2];
 
 // measure result
-measure q[2] -> c[2];
-measure q[1] -> c[1];
-measure q[0] -> c[0];
+measure q -> c;

--- a/cpp/sample_qasm/Quantum Phase Estimation (3 qubits).qasm
+++ b/cpp/sample_qasm/Quantum Phase Estimation (3 qubits).qasm
@@ -1,0 +1,43 @@
+OPENQASM 2.0;
+include "qelib1.inc";
+
+// estimating the phase of U=p(3pi/8) with 3-bit precision
+// we seek theta=3/16=0.0011_2, which is not exactly representable using 3 bits
+// the best we can expect is high probabilities for |1>*|001> and |1>*|010>
+
+// counting registers
+qreg q[3];
+
+// eigenstate register
+qreg psi[1];
+
+// classical registers
+creg c[3];
+
+// initialize eigenstate psi = |1>
+x psi;
+barrier psi;
+
+// initialise counting register to |+...+>
+h q;
+barrier q;
+
+// apply successive controlled rotations
+cp(1 * (3*pi/8)) psi, q[0];
+cp(2 * (3*pi/8)) psi, q[1];
+cp(4 * (3*pi/8)) psi, q[2];
+barrier q;
+
+// apply inverse QFT to counting qubits
+swap q[2], q[0];
+h q[0];
+cp(-pi/2) q[1], q[0];
+h q[1];
+cp(-pi/4) q[2], q[0];
+cp(-pi/2) q[2], q[1];
+h q[2];
+
+// measure result
+measure q[2] -> c[2];
+measure q[1] -> c[1];
+measure q[0] -> c[0];

--- a/cpp/sample_qasm/Quantum Phase Estimation (4 qubits).qasm
+++ b/cpp/sample_qasm/Quantum Phase Estimation (4 qubits).qasm
@@ -1,0 +1,50 @@
+OPENQASM 2.0;
+include "qelib1.inc";
+
+// estimating the phase of U=p(3pi/8) with 4-bit precision
+// we seek theta=3/16=0.0011_2, which is exactly representable using 4 bits
+// thus we expect to obtain |1> * |0011> with certainty
+
+// counting registers
+qreg q[4];
+
+// eigenstate register
+qreg psi[1];
+
+// classical registers
+creg c[4];
+
+// initialize eigenstate psi = |1>
+x psi;
+barrier psi;
+
+// initialise counting register to |+...+>
+h q;
+barrier q;
+
+// apply successive controlled rotations
+cp(1 * (3*pi/8)) psi, q[0];
+cp(2 * (3*pi/8)) psi, q[1];
+cp(4 * (3*pi/8)) psi, q[2];
+cp(8 * (3*pi/8)) psi, q[3];
+barrier q;
+
+// apply inverse QFT to counting qubits
+swap q[3], q[0];
+swap q[2], q[1];
+h q[0];
+cp(-pi/2) q[1], q[0];
+h q[1];
+cp(-pi/4) q[2], q[0];
+cp(-pi/2) q[2], q[1];
+h q[2];
+cp(-pi/8) q[3], q[0];
+cp(-pi/4) q[3], q[1];
+cp(-pi/2) q[3], q[2];
+h q[3];
+
+// measure result
+measure q[3] -> c[3];
+measure q[2] -> c[2];
+measure q[1] -> c[1];
+measure q[0] -> c[0];

--- a/cpp/sample_qasm/Quantum Phase Estimation (4 qubits).qasm
+++ b/cpp/sample_qasm/Quantum Phase Estimation (4 qubits).qasm
@@ -44,7 +44,4 @@ cp(-pi/2) q[3], q[2];
 h q[3];
 
 // measure result
-measure q[3] -> c[3];
-measure q[2] -> c[2];
-measure q[1] -> c[1];
-measure q[0] -> c[0];
+measure q -> c;

--- a/cpp/sample_qasm/W State (3 qubits).qasm
+++ b/cpp/sample_qasm/W State (3 qubits).qasm
@@ -1,0 +1,29 @@
+OPENQASM 2.0;
+include "qelib1.inc";
+
+qreg q[3];
+creg c[3];
+
+// initialize topmost qubit to |1>
+x q[2];
+barrier q;
+
+// split contributions with qubit 1 by rotating with angle arccos(sqrt(1/3))
+ry(-0.95531661812450928) q[1];
+cz q[2], q[1];
+ry(0.95531661812450928) q[1];
+barrier q;
+
+// split contributions with qubit 0 by rotating with angle arccos(sqrt(1/2)) = pi/4
+ry(-pi/4) q[0];
+cz q[1], q[0];
+ry(pi/4) q[0];
+barrier q;
+
+// apply CNOTs to obtain correct states
+cx q[1], q[2];
+cx q[0], q[1];
+
+measure q[2] -> c[2];
+measure q[1] -> c[1];
+measure q[0] -> c[0];

--- a/cpp/sample_qasm/W State (4 qubits).qasm
+++ b/cpp/sample_qasm/W State (4 qubits).qasm
@@ -1,0 +1,37 @@
+OPENQASM 2.0;
+include "qelib1.inc";
+
+qreg q[4];
+creg c[4];
+
+// initialize topmost qubit to |1>
+x q[3];
+barrier q;
+
+// split contributions with qubit 2 by rotating with angle arccos(sqrt(1/4)) = pi/3
+ry(-pi/3) q[2];
+cz q[3], q[2];
+ry(pi/3) q[2];
+barrier q;
+
+// split contributions with qubit 1 by rotating with angle arccos(sqrt(1/3))
+ry(-0.95531661812450928) q[1];
+cz q[2], q[1];
+ry(0.95531661812450928) q[1];
+barrier q;
+
+// split contributions with qubit 0 by rotating with angle arccos(sqrt(1/2)) = pi/4
+ry(-pi/4) q[0];
+cz q[1], q[0];
+ry(pi/4) q[0];
+barrier q;
+
+// apply CNOTs to obtain correct states
+cx q[2], q[3];
+cx q[1], q[2];
+cx q[0], q[1];
+
+measure q[3] -> c[3];
+measure q[2] -> c[2];
+measure q[1] -> c[1];
+measure q[0] -> c[0];

--- a/cpp/sample_qasm/W State (5 qubits).qasm
+++ b/cpp/sample_qasm/W State (5 qubits).qasm
@@ -1,0 +1,44 @@
+OPENQASM 2.0;
+include "qelib1.inc";
+
+qreg q[5];
+creg c[5];
+
+// initialize topmost qubit to |1>
+x q[4];
+barrier q;
+
+// split contributions with qubit 3 by rotating with angle arccos(sqrt(1/3))
+ry(-1.10714871779409050) q[3];
+cz q[4], q[3];
+ry(1.10714871779409050) q[3];
+barrier q;
+
+// split contributions with qubit 2 by rotating with angle arccos(sqrt(1/4)) = pi/3
+ry(-pi/3) q[2];
+cz q[3], q[2];
+ry(pi/3) q[2];
+barrier q;
+
+// split contributions with qubit 1 by rotating with angle arccos(sqrt(1/3))
+ry(-0.95531661812450928) q[1];
+cz q[2], q[1];
+ry(0.95531661812450928) q[1];
+barrier q;
+
+// split contributions with qubit 0 by rotating with angle arccos(sqrt(1/2)) = pi/4
+ry(-pi/4) q[0];
+cz q[1], q[0];
+ry(pi/4) q[0];
+barrier q;
+
+// apply CNOTs to obtain correct states
+cx q[3], q[4];
+cx q[2], q[3];
+cx q[1], q[2];
+cx q[0], q[1];
+
+measure q[3] -> c[3];
+measure q[2] -> c[2];
+measure q[1] -> c[1];
+measure q[0] -> c[0];

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "JKQ DDVis - A JKQ Tool for Visualizing Decision Diagrams for Quantum Computing",
   "main": "server.js",
   "scripts": {
-    "run": "cmake-js compile && node ./bin/www"
+    "build": "cmake-js compile --config Release --CDCMAKE_BUILD_PARALLEL_LEVEL=4",
+    "prerun": "npm run build",
+    "run": "node ./bin/www"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ddvis",
-  "version": "1.0.1",
+  "version": "1.4.0",
   "description": "JKQ DDVis - A JKQ Tool for Visualizing Decision Diagrams for Quantum Computing",
   "main": "server.js",
   "scripts": {

--- a/public/index.html
+++ b/public/index.html
@@ -100,6 +100,11 @@
             <input type="checkbox" id="cb_classic" title="Enable/disable classic decision diagram look"
                    onchange="updateExportOptions()" disabled/>
 
+            <br>
+            <label for="cb_polar" class="checkbox" title="Enable/disable polar format for complex numbers">Polar Coordinates</label>
+            <input type="checkbox" id="cb_polar" title="Enable/disable polar format for complex numbers"
+                   onchange="updateExportOptions()" checked disabled/>
+
         </div>
 
         <div class="settings-div">

--- a/public/javascripts/init.js
+++ b/public/javascripts/init.js
@@ -7,6 +7,7 @@ const step_duration = $('#stepDuration');
 const cb_colored = document.getElementById('cb_colored');
 const cb_edge_labels = document.getElementById('cb_edge_labels');
 const cb_classic = document.getElementById('cb_classic');
+const cb_polar = document.getElementById('cb_polar');
 
 const ex_algo_list = document.getElementById('ex_algo_list');
 const ex_algo_ver_loading = document.getElementById('ex_algo_ver_loading');

--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -93,7 +93,7 @@ function onTabChange(newTab) {
                     cb_colored.checked = res.colored ? 'checked' : '';
                     cb_edge_labels.checked = res.edgeLabels ? 'checked' : '';
                     cb_classic.checked = res.classic ? 'checked' : '';
-
+                    cb_polar.checked = res.polar ? 'checked' : '';
                 } else {
                     //endLoadingAnimation();
                     //changeState(STATE_LOADED_START);
@@ -114,8 +114,8 @@ function onTabChange(newTab) {
                     reset_btn.textContent = "Reset Algorithm";
                     reset_btn.style.display = "block";
 
-                    enableElementsWithID([ "cb_colored", "cb_edge_labels", "cb_classic" ]);
-                    disableElementsWithID([ "radio_algo1", "radio_algo2" ]);
+            enableElementsWithID(["cb_colored", "cb_edge_labels", "cb_classic", "cb_polar"]);
+            disableElementsWithID(["radio_algo1", "radio_algo2"]);
                     setExportOptions("sim");
                     break;
 
@@ -127,7 +127,7 @@ function onTabChange(newTab) {
 
                     enableElementsWithID([
                         "radio_algo1", "radio_algo2",
-                        "cb_colored", "cb_edge_labels", "cb_classic"
+                        "cb_colored", "cb_edge_labels", "cb_classic", "cb_polar"
                     ]);
                     setExportOptions("ver");
                     break;
@@ -138,7 +138,7 @@ function onTabChange(newTab) {
 
                     disableElementsWithID([
                         "radio_algo1", "radio_algo2",
-                        "cb_colored", "cb_edge_labels", "cb_classic"
+                        "cb_colored", "cb_edge_labels", "cb_classic", "cb_polar"
                     ]);
     }
 
@@ -326,13 +326,14 @@ function updateExportOptions() {
     const colored = cb_colored.checked;
     const edgeLabels = cb_edge_labels.checked;
     const classic = cb_classic.checked;
+    const polar = cb_polar.checked;
     //console.log(colored + ", " + edgeLabels + ", " + classic);
 
     if(curTab === SIM_TAB) {
-        sim_updateExportOptions(colored, edgeLabels, classic);
+        sim_updateExportOptions(colored, edgeLabels, classic, polar);
 
     } else if(curTab === VER_TAB) {
-        ver_updateExportOptions(colored, edgeLabels, classic);
+        ver_updateExportOptions(colored, edgeLabels, classic, polar);
     }
 }
 
@@ -348,7 +349,7 @@ const STATE_LOADED_EMPTY = 6;       //can't navigate
 
 const _generalElements = [
     "sim_tab", "ver_tab",
-    "stepDuration", "cb_colored", "cb_edge_labels", "cb_classic"
+    "stepDuration", "cb_colored", "cb_edge_labels", "cb_classic", "cb_polar"
 ];
 function generalChangeState(state) {
     switch (state) {
@@ -364,7 +365,7 @@ function generalChangeState(state) {
             for(let i = 0; i < ea_enable.length; i++) ea_enable[i].disabled = false;
 
             enableElementsWithID(_generalElements);
-            if(curTab === START_TAB) disableElementsWithID([ "cb_colored", "cb_edge_labels", "cb_classic" ]);
+            if (curTab === START_TAB) disableElementsWithID(["cb_colored", "cb_edge_labels", "cb_classic", "cb_polar"]);
             break;
 
         case STATE_SIMULATING:

--- a/public/javascripts/simulation.js
+++ b/public/javascripts/simulation.js
@@ -706,7 +706,7 @@ function formatAmplitude(num) {
 
 function formatPhase(num) {
     // set tolerance for detecting fraction
-    const maxDenominator = 128;
+    const maxDenominator = 1024;
     // transform to range [0, 2pi)
     var transform = (num+2*Math.PI) % (2*Math.PI);
     var numbypi = transform / Math.PI;
@@ -853,8 +853,9 @@ function plotAmplitudes(amplitudes) {
  * @param colored whether the edges should be colored based on their weight or be black and dotted/thick
  * @param edgeLabels whether the weights should be displayed as labels on the edges or not
  * @param classic whether a node should be a rounded-rectangle or a classical circle
+ * @param polar whether complex numbers should be formatted using polar coordinates
  */
-function sim_updateExportOptions(colored, edgeLabels, classic) {
+function sim_updateExportOptions(colored, edgeLabels, classic, polar) {
     const lastState = simState;
     const disablePrev = document.getElementById("prev").disabled;
     const disableToEnd = document.getElementById("toEnd").disabled;
@@ -865,7 +866,7 @@ function sim_updateExportOptions(colored, edgeLabels, classic) {
     const call = jQuery.ajax({
         type: 'PUT',
         url: 'updateExportOptions',
-        data: { colored: colored, edgeLabels: edgeLabels, classic: classic, updateDD: !algoArea.emptyAlgo, dataKey: dataKey },
+        data: {colored: colored, edgeLabels: edgeLabels, classic: classic, polar: polar, updateDD: !algoArea.emptyAlgo, dataKey: dataKey},
         success: (res) => {
             if (res.dot) {
                 print(res, () => {

--- a/public/javascripts/verification.js
+++ b/public/javascripts/verification.js
@@ -409,8 +409,9 @@ function ver_loadExAlgo(algo, format, algo1) {
  * @param colored whether the edges should be colored based on their weight or be black and dotted/thick
  * @param edgeLabels whether the weights should be displayed as labels on the edges or not
  * @param classic whether a node should be a rounded-rectangle or a classical circle
+ * @param polar whether complex numbers should be formatted using polar coordinates
  */
-function ver_updateExportOptions(colored, edgeLabels, classic) {
+function ver_updateExportOptions(colored, edgeLabels, classic, polar) {
     const lastState1 = ver1State;
     const lastState2 = ver2State;
     ver_changeState(STATE_SIMULATING, true);
@@ -427,8 +428,10 @@ function ver_updateExportOptions(colored, edgeLabels, classic) {
     const call = jQuery.ajax({
         type: 'PUT',
         url: 'updateExportOptions',
-        data: { colored: colored, edgeLabels: edgeLabels, classic: classic,
-            updateDD: updateDD, dataKey: dataKey, targetManager: "ver" },
+        data: {
+            colored: colored, edgeLabels: edgeLabels, classic: classic, polar: polar,
+            updateDD: updateDD, dataKey: dataKey, targetManager: "ver"
+        },
         success: (res) => {
             if (res.dot) ver_print(res, callback);
             else callback();

--- a/public/views/simulation.html
+++ b/public/views/simulation.html
@@ -82,6 +82,9 @@ An algorithm can be loaded in the following ways:
         <b>Classic</b>: This option allows to toggle a more classic decision diagram node style, which is more similar to the way decision diagrams are frequently visualized in research papers.
     </li>
     <li>
+        <b>Polar Coordinates</b>: This option allows switching between polar and rectangular coordinates for complex number visualization.
+    </li>
+    <li>
         <b>Step duration</b>: The minimum time for one transition when using the diashow feature. Note that the actual transition time might be longer in case of computationally expensive operations.
     </li>
 </ul>

--- a/public/views/verification.html
+++ b/public/views/verification.html
@@ -96,6 +96,9 @@
         <b>Classic</b>: This option allows to toggle a more classic decision diagram node style, which is more similar to the way decision diagrams are frequently visualized in research papers.
     </li>
     <li>
+        <b>Polar Coordinates</b>: This option allows switching between polar and rectangular coordinates for complex number visualization.
+    </li>
+    <li>
         <b>Step duration</b>: The minimum time for one transition when using the diashow feature. Note that the actual transition time might be longer in case of computationally expensive operations.
     </li>
 </ul>

--- a/routes/index.js
+++ b/routes/index.js
@@ -113,9 +113,10 @@ router.put('/updateExportOptions', (req, res) => {
         const showColored = req.body.colored === "true";
         const showEdgeLabels = req.body.edgeLabels === "true";
         const showClassic = req.body.classic === "true";
+        const usePolarCoordinates = req.body.polar === "true";
         const updateDD = req.body.updateDD === "true";
 
-        vis.updateExportOptions(showColored, showEdgeLabels, showClassic);
+        vis.updateExportOptions(showColored, showEdgeLabels, showClassic, usePolarCoordinates);
 
         if(vis.isReady() && updateDD) _sendDD(res, vis.getDD());
         else res.status(200).end(); //end the call without sending data


### PR DESCRIPTION
This PR upgrades the DD Package to its latest version. This includes updates for the visualization of complex numbers, which are now printed in polar coordinates per default. A switch is provided to change to the old behaviour.

It also includes updates to the QASM parser that allows to support even more gates natively (e.g., `mcphase`).

Furthermore, this PR adds further example algorithms to DDVis:
 - W State
 - Graph State
 - Quantum Phase Estimation
 - Iterative Quantum Phase Estimation

Last but not least, this PR also introduces CI (including clang-format) to DDVis.
At present, this only checks if the C++ code/bindings conform to the specified format and compile.